### PR TITLE
Add a rudimentary Ruby Gem finder to Soufi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,7 @@ Currently supported finders are:
  - Python sdists
  - Golang modules
  - Java JARs
+ - Ruby Gems
 
 If you want to download Alpine packages, you must have `git` installed.
 

--- a/soufi/__init__.py
+++ b/soufi/__init__.py
@@ -96,6 +96,16 @@ class Finder:
         )
         return cls.find(java_finder)
 
+    @classmethod
+    def gem(cls, name, version):
+        gem_finder = finder.factory(
+            "gem",
+            name=name,
+            version=version,
+            s_type=finder.SourceType.gem,
+        )
+        return cls.find(gem_finder)
+
 
 def make_archive_from_discovery_source(disc_src, fname):
     try:

--- a/soufi/finders/gem.py
+++ b/soufi/finders/gem.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# All rights reserved.
+
+import requests
+
+from soufi import exceptions, finder
+
+GEM_DOWNLOADS = 'https://rubygems.org/downloads/'
+API_TIMEOUT = 30  # seconds
+
+
+class GemFinder(finder.SourceFinder):
+    """Find Gem files.
+
+    Finds files at https://rubygems.org/downloads
+    """
+
+    distro = finder.SourceType.gem.value
+
+    def _find(self):
+        source_url = self.get_source_url()
+        return GemDiscoveredSource([source_url])
+
+    def get_source_url(self):
+        url = f"{GEM_DOWNLOADS}{self.name}-{self.version}.gem"
+        response = requests.head(url, timeout=API_TIMEOUT)
+        if response.status_code != requests.codes.ok:
+            raise exceptions.SourceNotFound
+        return url
+
+
+class GemDiscoveredSource(finder.DiscoveredSource):
+    """A discovered Gem package."""
+
+    make_archive = finder.DiscoveredSource.remote_url_is_archive
+    # NOTE(nic): `distro` and `archive_extension` are the same,
+    # so auto-output mode will name these things `.gem.gem`.  The
+    # recommended workaround is to not use auto-output mode :-)
+    archive_extension = '.gem'
+
+    def populate_archive(self, *args, **kwargs):  # pragma: no cover
+        # Required by the base class but Gems are already tarballs so
+        # nothing to do.
+        pass
+
+    def __repr__(self):
+        return self.urls[0]

--- a/soufi/tests/finders/test_gem_finder.py
+++ b/soufi/tests/finders/test_gem_finder.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# All rights reserved.
+
+from unittest import mock
+
+import requests
+import testtools
+
+from soufi import exceptions
+from soufi.finder import SourceType
+from soufi.finders import gem
+from soufi.testing import base
+
+
+class TestGemFinder(base.TestCase):
+    def make_finder(self, name=None, version=None):
+        if name is None:
+            name = self.factory.make_string('name')
+        if version is None:
+            version = self.factory.make_string('version')
+        return gem.GemFinder(name, version, SourceType.gem)
+
+    def make_response(self, code):
+        fake_response = mock.MagicMock()
+        fake_response.status_code = code
+        return fake_response
+
+    def test_get_source_url(self):
+        finder = self.make_finder()
+        url = f'{gem.GEM_DOWNLOADS}{finder.name}-{finder.version}.gem'
+
+        head = self.patch(requests, 'head')
+        head.return_value = self.make_response(requests.codes.ok)
+        found_url = finder.get_source_url()
+        self.assertEqual(found_url, url)
+        head.assert_called_once_with(url, timeout=30)
+
+    def test_get_source_info_raises_when_response_fails(self):
+        head = self.patch(requests, 'head')
+        head.return_value = self.make_response(requests.codes.not_found)
+        finder = self.make_finder()
+        with testtools.ExpectedException(exceptions.SourceNotFound):
+            finder.get_source_url()
+
+    def test_find(self):
+        url = self.factory.make_url()
+        finder = self.make_finder()
+        self.patch(finder, 'get_source_url').return_value = url
+
+        disc_source = finder.find()
+        self.assertIsInstance(disc_source, gem.GemDiscoveredSource)
+        self.assertEqual([url], disc_source.urls)
+
+
+class TestGemDiscoveredSource(base.TestCase):
+    def make_discovered_source(self, url=None):
+        if url is None:
+            url = self.factory.make_url()
+        return gem.GemDiscoveredSource([url])
+
+    def test_repr(self):
+        url = self.factory.make_url()
+        gem_discovered_source = self.make_discovered_source(url)
+        self.assertEqual(url, repr(gem_discovered_source))
+
+    def test_make_archive(self):
+        gds = self.make_discovered_source()
+        self.assertEqual(gds.make_archive, gds.remote_url_is_archive)

--- a/soufi/tests/test_factory.py
+++ b/soufi/tests/test_factory.py
@@ -29,6 +29,7 @@ class TestFinderFactory(base.TestCase):
             'alpine',
             'centos',
             'debian',
+            'gem',
             'go',
             'java',
             'npm',


### PR DESCRIPTION
Assembles Gem URLs on rubygems.org and tries to download them.  Does not support private/alternate Gem sources.

Fixes issue #2