### PR TITLE
Refactor Yum finders to use a common base class, add RHEL finder

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,7 @@ any existing downloadable archive.
 Currently supported finders are:
  - Debian OS packages
  - Ubuntu OS packages
+ - Red Hat (UBI) packages
  - CentOS packages
  - Alpine packages
  - Photon OS packages

--- a/soufi/__init__.py
+++ b/soufi/__init__.py
@@ -122,6 +122,18 @@ class Finder:
         )
         return cls.find(photon_finder)
 
+    @classmethod
+    def rhel(cls, name, version, source_repos=None, binary_repos=None):
+        rhel_finder = finder.factory(
+            "rhel",
+            name=name,
+            version=version,
+            s_type=finder.SourceType.os,
+            source_repos=source_repos,
+            binary_repos=binary_repos,
+        )
+        return cls.find(rhel_finder)
+
 
 def make_archive_from_discovery_source(disc_src, fname):
     try:
@@ -218,8 +230,8 @@ def main(
     name specifed.  If the original source is already an archive then that
     archive is used instead.
 
-    The sources currently supported are 'debian', 'ubuntu', 'centos', 'alpine',
-    'photon', 'java', 'go', 'python', and 'npm', one of which must be
+    The sources currently supported are 'debian', 'ubuntu', 'rhel', 'centos',
+    'alpine', 'photon', 'java', 'go', 'python', and 'npm', one of which must be
     specified as the DISTRO argument.
     """
     try:
@@ -243,7 +255,7 @@ def main(
                 source_repos=source_repo,
                 binary_repos=binary_repo,
             )
-        elif distro == 'photon':
+        elif distro in ('photon', 'rhel'):
             disc_source = func(
                 name,
                 version,

--- a/soufi/__init__.py
+++ b/soufi/__init__.py
@@ -52,7 +52,9 @@ class Finder:
         return cls.find(python_finder)
 
     @classmethod
-    def centos(cls, name, version, repos=None):
+    def centos(
+        cls, name, version, repos=None, source_repos=None, binary_repos=None
+    ):
         optimal = 'optimal' in repos
         centos_finder = finder.factory(
             "centos",
@@ -61,6 +63,8 @@ class Finder:
             s_type=finder.SourceType.os,
             repos=repos,
             optimal_repos=optimal,
+            source_repos=source_repos,
+            binary_repos=binary_repos,
         )
         return cls.find(centos_finder)
 
@@ -147,7 +151,7 @@ def make_archive_from_discovery_source(disc_src, fname):
 )
 @click.option(
     "--repo",
-    default=None,
+    default=(),
     multiple=True,
     help="For CentOS, name of repo to use instead of defaults. "
     "Use 'optimal' to use an extended optimal set. May be repeated.",
@@ -157,14 +161,16 @@ def make_archive_from_discovery_source(disc_src, fname):
     default=(),
     multiple=True,
     help="For Yum-based distros, URL of a source repo mirror to use "
-    "for lookups instead of the distro defaults. May be repeated. ",
+    "for lookups instead of the distro defaults. May be repeated. "
+    "On CentOS, this causes --repo to be ignored.",
 )
 @click.option(
     "--binary-repo",
     default=(),
     multiple=True,
     help="For Yum-based distros, URL of a binary repo mirror to use "
-    "for lookups instead of the distro defaults. May be repeated. ",
+    "for lookups instead of the distro defaults. May be repeated. "
+    "On CentOS, this causes --repo to be ignored.",
 )
 @click.option(
     "--goproxy",
@@ -230,7 +236,13 @@ def main(
         elif distro == 'alpine':
             disc_source = func(name, version, aports_dir=aports)
         elif distro == 'centos':
-            disc_source = func(name, version, repos=repo)
+            disc_source = func(
+                name,
+                version,
+                repos=repo,
+                source_repos=source_repo,
+                binary_repos=binary_repo,
+            )
         elif distro == 'photon':
             disc_source = func(
                 name,

--- a/soufi/finder.py
+++ b/soufi/finder.py
@@ -226,7 +226,11 @@ class FinderFactory:
         for _, module, _ in pkgutil.iter_modules(soufi.finders.__path__):
             mod = importlib.import_module(f"soufi.finders.{module}")
             for _name, obj in mod.__dict__.items():
-                if isclass(obj) and issubclass(obj, SourceFinder):
+                if (
+                    isclass(obj)
+                    and issubclass(obj, SourceFinder)
+                    and not hasattr(obj.distro, '__isabstractmethod__')
+                ):
                     # Add class object to our dict.
                     self._finders[obj.distro] = obj
 

--- a/soufi/finders/centos.py
+++ b/soufi/finders/centos.py
@@ -1,27 +1,34 @@
 # Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
-import functools
 import re
-import urllib
 from typing import Iterable
 
 # Bandit reports this as vulnerable but it's OK in lxml now,
 # defusedxml's lxml support is deprecated as a result.
-import repomd
-import requests
 from lxml import html  # nosec
 
-from soufi import exceptions, finder
+import soufi.finders.yum as yum_finder
+from soufi import finder
 
-VAULT = "https://vault.centos.org/centos/"
-TIMEOUT = 30  # seconds
+VAULT = "https://vault.centos.org/centos"
+DEFAULT_SEARCH = ('BaseOS', 'os', 'updates', 'extras')
+# Optimal search dirs considered a useful extended set to inspect in
+# addition to the defaults.
+OPTIMAL_SEARCH = ('AppStream', 'PowerTools', 'fasttrack')
+# CentOS is adorable sometimes.  The current release on mirror.centos.org
+# stores zero binary packages in the vault.  It does store all source
+# packages, however.  So when looking up binary package repos,
+# it is necessary to also check the main mirror when looking for the "current"
+# releases.  Note that the connection is unencrypted, and no HTTPS endpoint
+# is provided.
+MIRROR = "http://mirror.centos.org/centos"
 
 
-class CentosFinder(finder.SourceFinder):
+class CentosFinder(yum_finder.YumFinder):
     """Find CentOS source files.
 
-    Iterates over the index at https://vault.centos.org/
+    By default, iterates over the index at https://vault.centos.org
 
     :param repos: An iterable of repo names in the [S]Packages directory of
         the source repo. E.g. 'os', 'extras', etc. If not specified,
@@ -29,188 +36,94 @@ class CentosFinder(finder.SourceFinder):
     :param optimal_repos: (bool) Override repos to select what is considered
         an optimal set to inspect. These are the above defaults, plus:
         'AppStream', 'PowerTools', 'fasttrack'
-
-    The lookup is a 2-stage process:
-        1. A "fast" method of examining the index pages and looking for
-           files that match the package name and version. This depends on
-           the source package name being the same as the binary's and
-           will cover ~70% of the look-ups.
-        2. A slower fallback method, which downloads the repo's metadata
-           and does a direct look-up of the source package name.  This ONLY
-           works on version 8 of Centos because the Vault doesn't keep
-           binary repodata around for older releases.
     """
 
     distro = finder.Distro.centos.value
-
-    # List of default source directories in each release. These are the default
-    # ones that are inspected for source, and are inspected in the order given
-    # here, unless overridden in the constructor.
-    # TODO: Allow searching subdirs under these source dirs. The code currently
-    #   expects srpms directly under these.
-    default_source_dirs = [
-        'os/',
-        'BaseOS/',
-        'updates/',
-        'extras/',
-    ]
-
-    # Optimal source dirs considered a useful extended set to inspect in
-    # addition to the defaults.
-    optimal_source_dirs = [
-        'AppStream/',
-        'os/',
-        'BaseOS/',
-        'PowerTools',
-        'updates/',
-        'extras/',
-        'fasttrack/',
-    ]
 
     def __init__(
         self,
         *args,
         repos: Iterable[str] = None,
         optimal_repos: bool = False,
+        source_repos: Iterable[str] = None,
+        binary_repos: Iterable[str] = None,
         **kwargs,
     ):
-        if optimal_repos:
-            self.source_dirs = self.optimal_source_dirs
-        elif repos is not None:
-            self.source_dirs = [f"{repo}/" for repo in repos]
-        else:
-            self.source_dirs = self.default_source_dirs
-        super().__init__(*args, **kwargs)
-
-    def _find(self):
-        dirs = self._get_dirs()
-        # Start at the latest release and work backwards.
-        for dir_ in sorted(dirs, reverse=True):
-            for url, dir_listing in self._get_source_dirs_content(dir_):
-                ref = self._get_path(dir_listing)
-                if ref:
-                    target_url = f"{url}/{ref}"
-                    return CentosDiscoveredSource([target_url])
-
-        # If we get here, it's likely that the "fast" method has failed
-        # because the source package name doesn't match the binary's. We
-        # have one more way to look this up using the 'repomd' package,
-        # but that only works for v8 packages as the repo data only
-        # exists for that release on Vault.
-        if 'el8' in self.version:
-            url = self._repo_lookup()
-            if url:
-                return CentosDiscoveredSource([url])
-        raise exceptions.SourceNotFound
-
-    def _get_url(self, url):
-        response = requests.get(url, timeout=TIMEOUT)
-        if response.status_code != requests.codes.ok:
-            raise exceptions.DownloadError(response.reason)
-        return response.content
+        if not repos or optimal_repos is True:
+            repos = DEFAULT_SEARCH
+        if not source_repos:
+            source_repos = self._get_source_repos(repos, optimal_repos)
+        if not binary_repos:
+            binary_repos = self._get_binary_repos(repos, optimal_repos)
+        super().__init__(
+            *args,
+            source_repos=source_repos,
+            binary_repos=binary_repos,
+            **kwargs,
+        )
 
     def _get_dirs(self):
         """Get all the possible Vault dirs that could match."""
-        url = f"{VAULT}"
-        content = self._get_url(url)
+        content = self._get_url(VAULT)
         tree = html.fromstring(content)
         dirs = tree.xpath('//td[@class="indexcolname"]/a/text()')
-        dirs = [d for d in dirs if d[0].isdigit()]
+        # CentOS Vault is fond of symlinking the current point release to a
+        # directory with just the major version number, e.g., `6.10/`->`6/`.
+        # This means that such directories are inherently unstable and their
+        # contents are subject to change without notice, so we'll ignore
+        # them in favour of the "full" names.
+        dirs = [dir.rstrip('/') for dir in dirs if re.match(r'\d+\.\d', dir)]
 
-        # Do very basic checks to see if we can limit searched dirs based on
-        # the package version containing a 'elN' hint. Just look for 6/7/8
-        # versions for now.
-        el = re.search(r'.el([678])', self.version)
-        if el is not None:
-            dirs = [d for d in dirs if d[0] == el.expand(r'\1')]
+        # Walk the tree backwards, so that newer releases get searched first
+        return reversed(dirs)
 
-        return dirs
+    def _get_source_repos(self, subdirs: Iterable[str], optimal_repos: bool):
+        """Determine which source search paths are valid.
 
-    def _get_source_dirs_content(self, release_dir):
-        """Yield all content from dirs under release_dir that have source.
-
-        A Release dir is the dir under the top-level VAULT.
-        For example, '8/', which when appended to VAULT gives:
-            https://vault.centos.org/centos/8/
-        Under there, there are many directories that can contain packages,
-        and this function yields each in turn.
+        Spams the vault with HEAD requests and keeps the ones that hit.
         """
-        url = f"{VAULT}{release_dir}"
-        content = self._get_url(url)
-        tree = html.fromstring(content)
-        dirs = tree.xpath('//td[@class="indexcolname"]/a/text()')
-        packages_dir = "SPackages"
-        if int(release_dir[0]) < 6 or release_dir in ('6.1/', '6.0/'):
-            # Releases up to and including 6.1 use "Packages" as the dir
-            # name, and then inexplicably they started using SPackages.
-            packages_dir = "Packages"
+        source_repos = []
+        for dir in self._get_dirs():
+            for subdir in subdirs:
+                url = f"{VAULT}/{dir}/{subdir}/Source/"
+                if self._test_url(url + "repodata/"):
+                    source_repos.append(url)
+            if optimal_repos:
+                for subdir in OPTIMAL_SEARCH:
+                    url = f"{VAULT}/{dir}/{subdir}/Source/"
+                    if self._test_url(url + "repodata/"):
+                        source_repos.append(url)
+        return source_repos
 
-        # Attempt to only look up in the most common directories, to save time.
-        # (sets are not ordered, and we need to keep ordering, so cannot use
-        # set intersection here)
-        dirs = [d for d in dirs if d in self.source_dirs]
+    def _get_binary_repos(self, subdirs: Iterable[str], optimal_repos: bool):
+        """Determine which binary search paths are valid.
 
-        for dir_ in dirs:
-            try:
-                _url = f"{url}{dir_}Source/{packages_dir}"
-                yield _url, self._get_url(_url)
-            except exceptions.DownloadError:
-                pass
+        Spams the vault with HEAD requests and keeps the ones that hit.
+        """
+        binary_repos = []
+        for dir in self._get_dirs():
+            for subdir in subdirs:
+                vault_url = f"{VAULT}/{dir}/{subdir}/x86_64/"
+                mirror_url = f"{MIRROR}/{dir}/{subdir}/x86_64/"
+                if self._test_url(vault_url + "os/repodata/"):
+                    binary_repos.append(vault_url + "os/")
+                elif self._test_url(vault_url + "repodata/"):
+                    binary_repos.append(vault_url)
+                elif self._test_url(mirror_url + "os/repodata/"):
+                    binary_repos.append(mirror_url + "os/")
+                elif self._test_url(mirror_url + "repodata/"):
+                    binary_repos.append(mirror_url)
+            if optimal_repos:
+                for subdir in OPTIMAL_SEARCH:
+                    vault_url = f"{VAULT}/{dir}/{subdir}/x86_64/"
+                    mirror_url = f"{MIRROR}/{dir}/{subdir}/x86_64/"
+                    if self._test_url(vault_url + "os/repodata/"):
+                        binary_repos.append(vault_url + "os/")
+                    elif self._test_url(vault_url + "repodata/"):
+                        binary_repos.append(vault_url)
+                    elif self._test_url(mirror_url + "os/repodata/"):
+                        binary_repos.append(mirror_url + "os/")
+                    elif self._test_url(mirror_url + "repodata/"):
+                        binary_repos.append(mirror_url)
 
-    def _get_path(self, content):
-        """Given a dir on Vault, see if it contains the source HREF."""
-        # Grab source directory listing at dir and look for
-        # <name>-<version>.src.rpm.
-        tree = html.fromstring(content)
-        href = f"{self.name}-{self.version}.src.rpm"
-        ref = tree.xpath('//a[@href=$href]', href=href)
-        if ref:
-            return href
-        return None
-
-    def _repo_lookup(self):
-        for os_dir in self.source_dirs:
-            source_url = f"{VAULT}8/{os_dir}Source"
-            bin_url = f"{VAULT}8/{os_dir}x86_64/os"
-            repo = self._get_repo(bin_url)
-            if repo is None:
-                break
-            for package in repo.findall(self.name):
-                if package.evr == self.version:
-                    break
-            else:
-                break
-            source_nevra = package.sourcerpm
-            # Chop the '.src.rpm' from the end.
-            source_evr = source_nevra[:-8]
-            source_name, source_version = source_evr.split('-', 1)
-            src_repo = self._get_repo(source_url)
-            if src_repo is None:
-                break
-            for spackage in src_repo.findall(source_name):
-                if spackage.evr == source_version:
-                    return f"{source_url}/{spackage.location}"
-        return None
-
-    # Cache repo downloads as they are slow and network-bound.
-    @classmethod
-    @functools.lru_cache(maxsize=128)
-    def _get_repo(cls, url):
-        try:
-            return repomd.load(url)
-        except urllib.error.HTTPError:
-            return None
-
-
-class CentosDiscoveredSource(finder.DiscoveredSource):
-    """A discovered Centos source package."""
-
-    make_archive = finder.DiscoveredSource.remote_url_is_archive
-    archive_extension = '.src.rpm'
-
-    def populate_archive(self, *args, **kwargs):  # pragma: no cover
-        # Src RPMs are already compressed archives, nothing to do.
-        pass
-
-    def __repr__(self):
-        return self.urls[0]
+        return binary_repos

--- a/soufi/finders/photon.py
+++ b/soufi/finders/photon.py
@@ -1,157 +1,69 @@
 # Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
-# TODO(nic): this and the CentOS finder share a lot of the same "bones".  It
-#  may be worth refactoring them both to use common functionality.
-
-import functools
-import re
-import urllib
-
 # Bandit reports this as vulnerable but it's OK in lxml now,
 # defusedxml's lxml support is deprecated as a result.
-import repomd
-import requests
 from lxml import html  # nosec
 
-from soufi import exceptions, finder
+import soufi.exceptions
+import soufi.finders.yum as yum_finder
+from soufi import finder
 
-PHOTON_PACKAGES = "https://packages.vmware.com/photon/"
-TIMEOUT = 30  # seconds
+PHOTON_PACKAGES = "https://packages.vmware.com/photon"
 
 
-class PhotonFinder(finder.SourceFinder):
+class PhotonFinder(yum_finder.YumFinder):
     """Find Photon source files.
 
-    Iterates over the index at https://packages.vmware.com/photon/
-
-    The lookup is a 2-stage process:
-        1. A "fast" method of examining the index pages and looking for
-           files that match the package name and version. This depends on
-           the source package name being the same as the binary's and
-           will cover ~70% of the look-ups.
-        2. A slower fallback method, which downloads the repo's metadata
-           and does a direct look-up of the source package name.
+    By default, Iterates over the index at https://packages.vmware.com/photon
     """
 
     distro = finder.Distro.photon.value
 
-    def _find(self):
-        dir_ = self._get_dir()
-        for url, dir_listing in self._get_source_dirs_content(dir_):
-            ref = self._get_path(dir_listing)
-            if ref:
-                target_url = f"{url}{ref}"
-                return PhotonDiscoveredSource([target_url])
-
-        # If we get here, it's likely that the "fast" method has failed
-        # because the source package name doesn't match the binary's. We
-        # have one more way to look this up using the 'repomd' package
-        ref = self._repo_lookup(f"{PHOTON_PACKAGES}{dir_}")
-        if url and ref:
-            return PhotonDiscoveredSource([f'{url}{ref}'])
-        raise exceptions.SourceNotFound
-
-    def _get_url(self, url):
-        response = requests.get(url, timeout=TIMEOUT)
-        if response.status_code != requests.codes.ok:
-            raise exceptions.DownloadError(response.reason)
-        return response.content
-
-    def _get_dir(self, url=PHOTON_PACKAGES):
-        """Get the relevant package dir."""
-        content = self._get_url(url)
+    def _get_dirs(self):
+        content = self._get_url(PHOTON_PACKAGES)
         tree = html.fromstring(content)
-        dirs = tree.xpath('//a/text()')
-        dirs = [d for d in dirs if d[0].isdigit()]
+        retval = tree.xpath('//a/text()')
+        return reversed([dir for dir in retval if dir[0].isdigit()])
 
-        # Do very basic checks to see if we can limit searched dirs based on
-        # the package version containing a 'phN' hint.
-        el = re.search(r'.ph(\d)', self.version)
-        if el is not None:
-            dirs = [d for d in dirs if d[0] == el.expand(r'\1')]
+    def _get_repos(self, xpath):
+        dirs = []
+        for release_dir in self._get_dirs():
+            url = f"{PHOTON_PACKAGES}/{release_dir}"
+            try:
+                content = self._get_url(url)
+            except soufi.exceptions.DownloadError:
+                continue
+            tree = html.fromstring(content)
+            # Ideally all the SRPM trees would have the exact same
+            # packages in them, but their `aarch64` trees seem to be a
+            # little light.  Prefer x86_64 to be safe
+            dirs += [url + dir for dir in tree.xpath(xpath)]
+        return dirs
 
-        # We should only have 1 candidate directory left.  If not, give up,
-        # because something's gone wrong and we're not going to find it
-        if len(dirs) != 1:
-            raise exceptions.SourceNotFound
-        return dirs[0]
-
-    def _get_source_dirs_content(self, release_dir):
-        """Yield all content from dirs under release_dir that have source.
-
-        A Release dir is the dir under the top-level PHOTON_PACKAGES.
-        Under there, there are many directories that can contain packages,
-        and this function yields each in turn.
-        """
-        url = f"{PHOTON_PACKAGES}{release_dir}"
-        content = self._get_url(url)
-        tree = html.fromstring(content)
-        # Ideally all the SRPM trees would have the exact same packages in
-        # them, but their `aarch64` trees seem to be a little light.  Prefer
-        # x86_64 to be safe
-        dirs = tree.xpath(
+    def _get_source_repos(self):
+        return self._get_repos(
             "//a[text()[contains(.,'srpms')][contains(.,'x86_64')]]/text()"
         )
 
-        for dir_ in dirs:
-            try:
-                _url = f"{url}{dir_}"
-                yield _url, self._get_url(_url)
-            except exceptions.DownloadError:
-                pass
-
-    def _get_path(self, content):
-        """Given a dir, see if it contains the source HREF."""
-        # Grab source directory listing at dir and look for
-        # <name>-<version>.src.rpm.
-        tree = html.fromstring(content)
-        href = f"{self.name}-{self.version}.src.rpm"
-        ref = tree.xpath('//a[@href=$href]', href=href)
-        if ref:
-            return href
-        return None
-
-    def _repo_lookup(self, base_url):
-        content = self._get_url(base_url)
-        tree = html.fromstring(content)
-        os_dirs = tree.xpath(
-            "//a[contains(.,'updates') "
-            "or contains(.,'release') "
-            "or contains(.,'extras')]/text()"
+    def _get_binary_repos(self):
+        return self._get_repos(
+            "//a[text()[not(contains(.,'srpms'))][contains(.,'x86_64')]]/text()"  # noqa: E501
         )
-        for os_dir in os_dirs:
-            bin_url = f"{base_url}{os_dir}"
-            repo = self._get_repo(bin_url)
-            if repo is None:
-                break
-            for package in repo.findall(self.name):
-                if package.evr == self.version:
-                    break
-            else:
-                continue
-            return package.sourcerpm
-        return None
 
-    # Cache repo downloads as they are slow and network-bound.
-    @classmethod
-    @functools.lru_cache(maxsize=128)
-    def _get_repo(cls, url):
-        try:
-            return repomd.load(url)
-        except urllib.error.HTTPError:
+    def _walk_source_repos(self, name, version=None):
+        # Photon OS does not provide repomd.xml files for their source
+        # repositories, so we need to override the wonderful source lookup
+        # methods with...  this.
+
+        # Short-circuit here to force a binary package lookup in the caller
+        if version is None:
             return None
 
-
-class PhotonDiscoveredSource(finder.DiscoveredSource):
-    """A discovered Photon source package."""
-
-    make_archive = finder.DiscoveredSource.remote_url_is_archive
-    archive_extension = '.src.rpm'
-
-    def populate_archive(self, *args, **kwargs):  # pragma: no cover
-        # Src RPMs are already compressed archives, nothing to do.
-        pass
-
-    def __repr__(self):
-        return self.urls[0]
+        # Re-assemble a source package name, and try to fetch it from all
+        # the source repos.  This is startlingly effective.
+        for repo in self.source_repos:
+            url = f"{repo.rstrip('/')}/{name}-{version}.src.rpm"
+            if self._test_url(url):
+                return url
+        return None

--- a/soufi/finders/photon.py
+++ b/soufi/finders/photon.py
@@ -21,7 +21,7 @@ class PhotonFinder(yum_finder.YumFinder):
     distro = finder.Distro.photon.value
 
     def _get_dirs(self):
-        content = self._get_url(PHOTON_PACKAGES)
+        content = self.get_url(PHOTON_PACKAGES)
         tree = html.fromstring(content)
         retval = tree.xpath('//a/text()')
         return reversed([dir for dir in retval if dir[0].isdigit()])
@@ -31,7 +31,7 @@ class PhotonFinder(yum_finder.YumFinder):
         for release_dir in self._get_dirs():
             url = f"{PHOTON_PACKAGES}/{release_dir}"
             try:
-                content = self._get_url(url)
+                content = self.get_url(url)
             except soufi.exceptions.DownloadError:
                 continue
             tree = html.fromstring(content)
@@ -41,12 +41,12 @@ class PhotonFinder(yum_finder.YumFinder):
             dirs += [url + dir for dir in tree.xpath(xpath)]
         return dirs
 
-    def _get_source_repos(self):
+    def get_source_repos(self):
         return self._get_repos(
             "//a[text()[contains(.,'srpms')][contains(.,'x86_64')]]/text()"
         )
 
-    def _get_binary_repos(self):
+    def get_binary_repos(self):
         return self._get_repos(
             "//a[text()[not(contains(.,'srpms'))][contains(.,'x86_64')]]/text()"  # noqa: E501
         )
@@ -64,6 +64,6 @@ class PhotonFinder(yum_finder.YumFinder):
         # the source repos.  This is startlingly effective.
         for repo in self.source_repos:
             url = f"{repo.rstrip('/')}/{name}-{version}.src.rpm"
-            if self._test_url(url):
+            if self.test_url(url):
                 return url
         return None

--- a/soufi/finders/rhel.py
+++ b/soufi/finders/rhel.py
@@ -32,11 +32,11 @@ class RHELFinder(yum_finder.YumFinder):
         'ubi/atomic/7/7Server/x86_64',
     )
 
-    def _get_source_repos(self):
+    def get_source_repos(self):
         return [
             f"{DEFAULT_REPO}/{dir}/source/SRPMS"
             for dir in self.default_search_dirs
         ]
 
-    def _get_binary_repos(self):
+    def get_binary_repos(self):
         return [f"{DEFAULT_REPO}/{dir}/os" for dir in self.default_search_dirs]

--- a/soufi/finders/rhel.py
+++ b/soufi/finders/rhel.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# All rights reserved.
+
+import soufi.finders.yum as yum_finder
+from soufi import finder
+
+DEFAULT_REPO = "https://cdn-ubi.redhat.com/content/public/ubi/dist"
+
+
+class RHELFinder(yum_finder.YumFinder):
+    """Find Red Hat Enterprise Linux source files.
+
+    By default, uses the public UBI index at https://cdn-ubi.redhat.com
+    """
+
+    distro = finder.Distro.rhel.value
+
+    # UBI is kind of sprawling, and they are fairly idiosyncratic with where
+    # they like to put their packages, tree-wise.  Once you find the proper
+    # subtree, they are delightfully regular with the repo structure, however.
+    # Rather than aimlessly poke around their CDN, we'll use this
+    # hand-curated list of search paths.
+    default_search_dirs = (
+        'ubi8/8/x86_64/baseos',
+        'ubi8/8/x86_64/appstream',
+        'ubi8/8/x86_64/codeready-builder',
+        'ubi/server/7/7Server/x86_64',
+        'ubi/server/7/7Server/x86_64/extras',
+        'ubi/server/7/7Server/x86_64/devtools/1',
+        'ubi/server/7/7Server/x86_64/optional',
+        'ubi/server/7/7Server/x86_64/rhscl/1',
+        'ubi/atomic/7/7Server/x86_64',
+    )
+
+    def _get_source_repos(self):
+        return [
+            f"{DEFAULT_REPO}/{dir}/source/SRPMS"
+            for dir in self.default_search_dirs
+        ]
+
+    def _get_binary_repos(self):
+        return [f"{DEFAULT_REPO}/{dir}/os" for dir in self.default_search_dirs]

--- a/soufi/finders/yum.py
+++ b/soufi/finders/yum.py
@@ -138,7 +138,7 @@ class YumFinder(finder.SourceFinder, metaclass=abc.ABCMeta):
 
     # Cache repo downloads as they are slow and network-bound.
     @classmethod
-    @functools.lru_cache(maxsize=128)
+    @functools.lru_cache(maxsize=1024)
     def _get_repo(cls, url):
         if not url.endswith('/'):
             url += '/'
@@ -183,8 +183,10 @@ class YumFinder(finder.SourceFinder, metaclass=abc.ABCMeta):
         except requests.exceptions.Timeout:
             return False
 
+    # Generally we just want functools.cache here, but a strictly unbounded
+    # cache is just a bad idea
     @staticmethod
-    @functools.lru_cache(maxsize=128)
+    @functools.lru_cache(maxsize=1048576)
     def _head_url(url):
         response = requests.head(url, timeout=TIMEOUT)
         return response.status_code == requests.codes.ok

--- a/soufi/finders/yum.py
+++ b/soufi/finders/yum.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# All rights reserved.
+
+import abc
+import functools
+import urllib
+
+import repomd
+import requests
+
+from soufi import exceptions, finder
+
+TIMEOUT = 30  # seconds
+
+
+class YumFinder(finder.SourceFinder, metaclass=abc.ABCMeta):
+    """An abstract base class for making Yum-based finders.
+
+    Subclasses of this should provide methods for setting up the repository
+    search lists to pass to __init__.
+
+    The lookup is a 2-stage process:
+        1. Attempt to look up the SRPM directly from the sources repository.
+           In these cases, we use the name only and ignore the version,
+           since it is a very common practice for repositories to only
+           publish repodata for the "current" version, while still
+           providing older sources.
+        2. Attempt to look up the name of the source RPM from the binary
+           repository.  This will catch packages where the source and
+           binary package names do not match.  The version is also ignored
+           in this step, for the same reasons.  Then backtrack and attempt
+           to lookup that package in the source repos.
+    """
+
+    def __init__(self, *args, source_repos=None, binary_repos=None, **kwargs):
+        self.source_repos = source_repos
+        if not self.source_repos:
+            self.source_repos = self._get_source_repos()
+
+        self.binary_repos = binary_repos
+        if not self.binary_repos:
+            self.binary_repos = self._get_binary_repos()
+
+        super().__init__(*args, **kwargs)
+
+    @abc.abstractmethod
+    def _get_source_repos(self):
+        raise NotImplementedError  # pragma: nocover
+
+    @abc.abstractmethod
+    def _get_binary_repos(self):
+        raise NotImplementedError  # pragma: nocover
+
+    def _find(self):
+        source_url = self.get_source_url()
+        return YumDiscoveredSource([source_url])
+
+    def get_source_url(self):
+        # The easy part: try to find the package in the source repos.
+        url = self._walk_source_repos(self.name)
+        if url is None:
+            # The hard part: try to find the package in the binary repos,
+            # then backtrack into the source repos with the name and version
+            # of the SRPM provided
+            source_name, source_ver = self._walk_binary_repos(self.name)
+            if source_name is None:
+                raise exceptions.SourceNotFound
+
+            url = self._walk_source_repos(source_name, source_ver)
+        if url is None:
+            raise exceptions.SourceNotFound
+
+        # If we have a URL, but it's no good, we don't have a URL.
+        if not self._test_url(url):
+            raise exceptions.SourceNotFound
+
+        return url
+
+    def _walk_source_repos(self, name, version=None):
+        if version is None:
+            version = self.version
+        packages = []
+        for repo_url in self.source_repos:
+            repo = self._get_repo(repo_url)
+            if repo is None:
+                continue
+            for package in repo.findall(name):
+                # If the package version in the repomd is our version,
+                # it's easy.  Note that we want to match epoch-full and
+                # epoch-less version formats.
+                if version in (package.evr, package.vr):
+                    return repo.baseurl + package.location
+                # Otherwise let's make it weird
+                packages.append(package)
+
+            # If we've made it here, things have gotten weird.  Replace the
+            # version+release info in all unique package locations with our
+            # version and see if they exist.  This should find superseded
+            # packages that are present in the repo, but not in the repomd.
+            locs = set(p.location.replace(p.vr, version) for p in packages)
+            for loc in locs:
+                if self._test_url(repo.baseurl + loc):
+                    return repo.baseurl + loc
+        return None
+
+    def _walk_binary_repos(self, name):
+        packages = []
+        for repo_url in self.binary_repos:
+            repo = self._get_repo(repo_url)
+            if repo is None:
+                continue
+            for package in repo.findall(name):
+                # If we have a binary package matching our version, but with
+                # a different name than the corresponding source package,
+                # return the NVR fields
+                if self.version in (package.evr, package.vr):
+                    return self._nevra_or_none(package)
+                # Otherwise let's make it weird
+                packages.append(package)
+
+        # If we've made it here, things have gotten weird; this should be
+        # the case of a source RPM that produces binary RPMs with different
+        # names *and* versions (the lvm2 package from Red Hat is a good example
+        # of this).  In this case, we won't be able to make heads or tails of
+        # the response, unless (and only unless) it contains a single package.
+        try:
+            [package] = packages
+        except ValueError:
+            return None, None
+        return self._nevra_or_none(package)
+
+    def _nevra_or_none(self, package):
+        if package.sourcerpm == '':
+            # It's here, but has no sources defined!  Bummer...
+            return None, None
+        nevra = self._get_nevra(package.sourcerpm)
+        return nevra['name'], f"{nevra['ver']}-{nevra['rel']}"
+
+    # Cache repo downloads as they are slow and network-bound.
+    @classmethod
+    @functools.lru_cache(maxsize=128)
+    def _get_repo(cls, url):
+        if not url.endswith('/'):
+            url += '/'
+        try:
+            return repomd.load(url)
+        except urllib.error.HTTPError:
+            return None
+
+    # TODO(nic): throw this out and use hawkey/libdnf whenever that finally
+    #  stabilizes.  See: https://github.com/juledwar/soufi/issues/13
+    @staticmethod
+    def _get_nevra(filename):
+        """Split out the NEVRA fields from an RPM filename."""
+
+        # It's easiest to do this by eating the filename backwards, dropping
+        # offset pointers as we go
+        if filename.endswith('.rpm'):
+            filename = filename[:-4]
+        arch_offset = filename.rfind('.')
+        arch = filename[1 + arch_offset :]
+        rel_offset = filename[:arch_offset].rfind('-')
+        rel = filename[1 + rel_offset : arch_offset]
+        ver_offset = filename[:rel_offset].rfind('-')
+        ver = filename[1 + ver_offset : rel_offset]
+        name = filename[:ver_offset]
+        # Sometimes the epoch is before the name, sometimes it's before the
+        # version.  Support both.
+        if ':' in ver:
+            epoch, ver = ver.split(':', maxsplit=1)
+        elif ':' in name:
+            epoch, name = name.split(':', maxsplit=1)
+        else:
+            epoch = ''
+        return dict(name=name, ver=ver, rel=rel, epoch=epoch, arch=arch)
+
+    # Use this wrapper for doing HTTP HEAD requests, as it will swallow
+    # Timeout exceptions, but cache other lookups.
+    @staticmethod
+    def _test_url(url):
+        try:
+            return YumFinder._head_url(url)
+        except requests.exceptions.Timeout:
+            return False
+
+    @staticmethod
+    @functools.lru_cache(maxsize=128)
+    def _head_url(url):
+        response = requests.head(url, timeout=TIMEOUT)
+        return response.status_code == requests.codes.ok
+
+    @staticmethod
+    @functools.lru_cache(maxsize=128)
+    def _get_url(url):
+        # Not used directly by this class, but subclasses tend to need it.
+        response = requests.get(url, timeout=TIMEOUT)
+        if response.status_code != requests.codes.ok:
+            raise exceptions.DownloadError(response.reason)
+        return response.content
+
+
+class YumDiscoveredSource(finder.DiscoveredSource):
+    """A discovered Red Hat source package."""
+
+    make_archive = finder.DiscoveredSource.remote_url_is_archive
+    archive_extension = '.src.rpm'
+
+    def populate_archive(self, *args, **kwargs):  # pragma: no cover
+        # Src RPMs are already compressed archives, nothing to do.
+        pass
+
+    def __repr__(self):
+        return self.urls[0]

--- a/soufi/tests/finders/test_centos_finder.py
+++ b/soufi/tests/finders/test_centos_finder.py
@@ -15,7 +15,7 @@ class BaseCentosTest(base.TestCase):
     def setUp(self):
         super().setUp()
         yum.YumFinder._get_repo.cache_clear()
-        yum.YumFinder._get_url.cache_clear()
+        yum.YumFinder.get_url.cache_clear()
 
     def make_finder(self, name=None, version=None, **kwargs):
         if name is None:
@@ -57,8 +57,8 @@ class TestCentosFinder(BaseCentosTest):
     def test_initializer_finds_repos_when_called_with_no_args(self):
         name = self.factory.make_string('name')
         version = self.factory.make_string('version')
-        get_source_repos = self.patch(centos.CentosFinder, '_get_source_repos')
-        get_binary_repos = self.patch(centos.CentosFinder, '_get_binary_repos')
+        get_source_repos = self.patch(centos.CentosFinder, 'get_source_repos')
+        get_binary_repos = self.patch(centos.CentosFinder, 'get_binary_repos')
         centos.CentosFinder(name, version, SourceType.os)
         get_source_repos.assert_called_once_with(centos.DEFAULT_SEARCH, False)
         get_binary_repos.assert_called_once_with(centos.DEFAULT_SEARCH, False)
@@ -80,9 +80,9 @@ class TestCentosFinder(BaseCentosTest):
         subdirs = [self.factory.make_string() for _ in range(3)]
         get_dirs = self.patch(finder, '_get_dirs')
         get_dirs.return_value = dirs
-        test_url = self.patch(finder, '_test_url')
+        test_url = self.patch(finder, 'test_url')
         test_url.return_value = True
-        result = list(finder._get_source_repos(subdirs, False))
+        result = list(finder.get_source_repos(subdirs, False))
         expected = [
             f"{centos.VAULT}/{dir}/{subdir}/Source/"
             for dir in dirs
@@ -96,9 +96,9 @@ class TestCentosFinder(BaseCentosTest):
         subdirs = [self.factory.make_string() for _ in range(3)]
         get_dirs = self.patch(finder, '_get_dirs')
         get_dirs.return_value = dirs
-        test_url = self.patch(finder, '_test_url')
+        test_url = self.patch(finder, 'test_url')
         test_url.return_value = True
-        result = list(finder._get_source_repos(subdirs, True))
+        result = list(finder.get_source_repos(subdirs, True))
         expected = [
             f"{centos.VAULT}/{dir}/{subdir}/Source/"
             for dir in dirs
@@ -112,9 +112,9 @@ class TestCentosFinder(BaseCentosTest):
         subdirs = [self.factory.make_string() for _ in range(3)]
         get_dirs = self.patch(finder, '_get_dirs')
         get_dirs.return_value = dirs
-        test_url = self.patch(finder, '_test_url')
+        test_url = self.patch(finder, 'test_url')
         test_url.return_value = True
-        result = list(finder._get_binary_repos(subdirs, False))
+        result = list(finder.get_binary_repos(subdirs, False))
         expected = [
             f"{centos.VAULT}/{dir}/{subdir}/x86_64/os/"
             for dir in dirs
@@ -128,9 +128,9 @@ class TestCentosFinder(BaseCentosTest):
         subdirs = [self.factory.make_string() for _ in range(3)]
         get_dirs = self.patch(finder, '_get_dirs')
         get_dirs.return_value = dirs
-        test_url = self.patch(finder, '_test_url')
+        test_url = self.patch(finder, 'test_url')
         test_url.side_effect = itertools.cycle((False, True))
-        result = list(finder._get_binary_repos(subdirs, False))
+        result = list(finder.get_binary_repos(subdirs, False))
         expected = [
             f"{centos.VAULT}/{dir}/{subdir}/x86_64/"
             for dir in dirs
@@ -144,9 +144,9 @@ class TestCentosFinder(BaseCentosTest):
         subdirs = [self.factory.make_string() for _ in range(3)]
         get_dirs = self.patch(finder, '_get_dirs')
         get_dirs.return_value = dirs
-        test_url = self.patch(finder, '_test_url')
+        test_url = self.patch(finder, 'test_url')
         test_url.side_effect = itertools.cycle((False, False, True))
-        result = list(finder._get_binary_repos(subdirs, False))
+        result = list(finder.get_binary_repos(subdirs, False))
         expected = [
             f"{centos.MIRROR}/{dir}/{subdir}/x86_64/os/"
             for dir in dirs
@@ -160,9 +160,9 @@ class TestCentosFinder(BaseCentosTest):
         subdirs = [self.factory.make_string() for _ in range(3)]
         get_dirs = self.patch(finder, '_get_dirs')
         get_dirs.return_value = dirs
-        test_url = self.patch(finder, '_test_url')
+        test_url = self.patch(finder, 'test_url')
         test_url.side_effect = itertools.cycle((False, False, False, True))
-        result = list(finder._get_binary_repos(subdirs, False))
+        result = list(finder.get_binary_repos(subdirs, False))
         expected = [
             f"{centos.MIRROR}/{dir}/{subdir}/x86_64/"
             for dir in dirs
@@ -176,9 +176,9 @@ class TestCentosFinder(BaseCentosTest):
         subdirs = [self.factory.make_string() for _ in range(3)]
         get_dirs = self.patch(finder, '_get_dirs')
         get_dirs.return_value = dirs
-        test_url = self.patch(finder, '_test_url')
+        test_url = self.patch(finder, 'test_url')
         test_url.return_value = True
-        result = list(finder._get_binary_repos(subdirs, True))
+        result = list(finder.get_binary_repos(subdirs, True))
         expected = [
             f"{centos.VAULT}/{dir}/{subdir}/x86_64/os/"
             for dir in dirs
@@ -192,9 +192,9 @@ class TestCentosFinder(BaseCentosTest):
         subdirs = [self.factory.make_string() for _ in range(3)]
         get_dirs = self.patch(finder, '_get_dirs')
         get_dirs.return_value = dirs
-        test_url = self.patch(finder, '_test_url')
+        test_url = self.patch(finder, 'test_url')
         test_url.side_effect = itertools.cycle((False, True))
-        result = list(finder._get_binary_repos(subdirs, True))
+        result = list(finder.get_binary_repos(subdirs, True))
         expected = [
             f"{centos.VAULT}/{dir}/{subdir}/x86_64/"
             for dir in dirs
@@ -208,9 +208,9 @@ class TestCentosFinder(BaseCentosTest):
         subdirs = [self.factory.make_string() for _ in range(3)]
         get_dirs = self.patch(finder, '_get_dirs')
         get_dirs.return_value = dirs
-        test_url = self.patch(finder, '_test_url')
+        test_url = self.patch(finder, 'test_url')
         test_url.side_effect = itertools.cycle((False, False, True))
-        result = list(finder._get_binary_repos(subdirs, True))
+        result = list(finder.get_binary_repos(subdirs, True))
         expected = [
             f"{centos.MIRROR}/{dir}/{subdir}/x86_64/os/"
             for dir in dirs
@@ -224,9 +224,9 @@ class TestCentosFinder(BaseCentosTest):
         subdirs = [self.factory.make_string() for _ in range(3)]
         get_dirs = self.patch(finder, '_get_dirs')
         get_dirs.return_value = dirs
-        test_url = self.patch(finder, '_test_url')
+        test_url = self.patch(finder, 'test_url')
         test_url.side_effect = itertools.cycle((False, False, False, True))
-        result = list(finder._get_binary_repos(subdirs, True))
+        result = list(finder.get_binary_repos(subdirs, True))
         expected = [
             f"{centos.MIRROR}/{dir}/{subdir}/x86_64/"
             for dir in dirs
@@ -240,7 +240,7 @@ class TestCentosFinder(BaseCentosTest):
         version = self.factory.make_string('version')
         finder = self.make_finder(source_repos=None)
         super_method = self.patch(yum.YumFinder, '_walk_source_repos')
-        generator_reinit = self.patch(finder, '_get_source_repos')
+        generator_reinit = self.patch(finder, 'get_source_repos')
         # Ensure that a fresh generator is spawned before walking repos
         finder._walk_source_repos(name, version=version)
         super_method.assert_called_once_with(name, version=version)
@@ -252,7 +252,7 @@ class TestCentosFinder(BaseCentosTest):
         version = self.factory.make_string('version')
         finder = self.make_finder()
         super_method = self.patch(yum.YumFinder, '_walk_source_repos')
-        generator_reinit = self.patch(finder, '_get_source_repos')
+        generator_reinit = self.patch(finder, 'get_source_repos')
         # Since there is no generator in play, no re-init should occur.
         finder._walk_source_repos(name, version=version)
         super_method.assert_called_once_with(name, version=version)
@@ -263,7 +263,7 @@ class TestCentosFinder(BaseCentosTest):
         name = self.factory.make_string('name')
         finder = self.make_finder(binary_repos=None)
         super_method = self.patch(yum.YumFinder, '_walk_binary_repos')
-        generator_reinit = self.patch(finder, '_get_binary_repos')
+        generator_reinit = self.patch(finder, 'get_binary_repos')
         # Ensure that a fresh generator is spawned before walking repos
         finder._walk_binary_repos(name)
         super_method.assert_called_once_with(name)
@@ -274,7 +274,7 @@ class TestCentosFinder(BaseCentosTest):
         name = self.factory.make_string('name')
         finder = self.make_finder()
         super_method = self.patch(yum.YumFinder, '_walk_binary_repos')
-        generator_reinit = self.patch(finder, '_get_binary_repos')
+        generator_reinit = self.patch(finder, 'get_binary_repos')
         # Since there is no generator in play, no re-init should occur.
         finder._walk_binary_repos(name)
         super_method.assert_called_once_with(name)

--- a/soufi/tests/finders/test_centos_finder.py
+++ b/soufi/tests/finders/test_centos_finder.py
@@ -71,7 +71,7 @@ class TestCentosFinder(BaseCentosTest):
         get.return_value = self.make_response(top_data, requests.codes.ok)
         result = list(finder._get_dirs())
         # Ensure that only the items we're interested in come back
-        self.assertEqual([top_repos[3], top_repos[1], top_repos[0]], result)
+        self.assertEqual(['3.7.89', '2.1.3456', '1.0.123'], result)
         get.assert_called_once_with(centos.VAULT, timeout=30)
 
     def test__get_source_repos(self):

--- a/soufi/tests/finders/test_centos_finder.py
+++ b/soufi/tests/finders/test_centos_finder.py
@@ -1,25 +1,31 @@
 # Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
-import urllib
+import itertools
 from unittest import mock
 
 import requests
-import testtools
-from testtools.matchers._basic import SameMembers
 
-from soufi import exceptions
 from soufi.finder import SourceType
-from soufi.finders import centos
+from soufi.finders import centos, yum
 from soufi.testing import base
 
 
 class BaseCentosTest(base.TestCase):
+    def setUp(self):
+        super().setUp()
+        yum.YumFinder._get_repo.cache_clear()
+        yum.YumFinder._get_url.cache_clear()
+
     def make_finder(self, name=None, version=None, **kwargs):
         if name is None:
             name = self.factory.make_string('name')
         if version is None:
             version = self.factory.make_string('version')
+        if 'source_repos' not in kwargs:
+            kwargs['source_repos'] = ['']
+        if 'binary_repos' not in kwargs:
+            kwargs['binary_repos'] = ['']
         return centos.CentosFinder(name, version, SourceType.os, **kwargs)
 
     def make_response(self, data, code):
@@ -38,289 +44,192 @@ class BaseCentosTest(base.TestCase):
         links = [self.make_td(self.make_href(v)) for v in versions]
         return "\n".join(links)
 
-    def make_index_page_content(self, name, version):
-        # Makes something approximating the package index page from
-        # vault.centos.org with our desired package at a random place.
-        random_position = self.factory.randint(1, 8)
-        rows = []
-        for i in range(0, 10):
-            if i == random_position:
-                name_ = name
-                version_ = version
-            else:
-                name_ = self.factory.make_string('name')
-                version_ = self.factory.make_string('version')
-            rows.append(
-                self.make_td(self.make_href(f'{name_}-{version_}.src.rpm'))
-            )
-        return (
-            b'<table id="indexlist">\n'
-            + b'\n'.join(f'<tr>{row}</tr>'.encode('utf8') for row in rows)
-            + b'</table>'
-        )
-
 
 class TestCentosFinder(BaseCentosTest):
-    def setUp(self):
-        super().setUp()
-        # Make sure this doesn't interfere with fast lookup tests.
-        self.patch(centos.CentosFinder, '_repo_lookup').return_value = None
-
-    def test_source_dirs_setup_default(self):
+    def test_find(self):
         finder = self.make_finder()
-        self.assertEqual(finder.source_dirs, finder.default_source_dirs)
+        url = self.factory.make_url()
+        self.patch(finder, 'get_source_url').return_value = url
+        disc_source = finder.find()
+        self.assertIsInstance(disc_source, yum.YumDiscoveredSource)
+        self.assertEqual([url], disc_source.urls)
 
-    def test_source_dirs_setup_optimal(self):
-        finder = self.make_finder(optimal_repos=True)
-        self.assertEqual(finder.source_dirs, finder.optimal_source_dirs)
-
-    def test_source_dirs_setup_custom(self):
-        repos = ['foo', 'bar', 'baz']
-        finder = self.make_finder(repos=repos)
-        expected_repos = [f"{r}/" for r in repos]
-        self.assertEqual(finder.source_dirs, expected_repos)
+    def test_initializer_finds_repos_when_called_with_no_args(self):
+        name = self.factory.make_string('name')
+        version = self.factory.make_string('version')
+        get_source_repos = self.patch(centos.CentosFinder, '_get_source_repos')
+        get_binary_repos = self.patch(centos.CentosFinder, '_get_binary_repos')
+        centos.CentosFinder(name, version, SourceType.os)
+        get_source_repos.assert_called_once_with(centos.DEFAULT_SEARCH, False)
+        get_binary_repos.assert_called_once_with(centos.DEFAULT_SEARCH, False)
 
     def test__get_dirs(self):
         finder = self.make_finder()
-        versions = ['4.5', '7.0', '7.1', '8.0']
-        versions_ = versions + ['ignored']
-        data = self.make_top_page_content(versions_)
+        top_repos = ('1.0.123', '2.1.3456', 'bogus', '3.7.89', '3')
+        top_data = self.make_top_page_content(top_repos)
         get = self.patch(requests, 'get')
-        get.return_value = self.make_response(data, requests.codes.ok)
-        dirs = finder._get_dirs()
-        self.assertEqual(versions, dirs)
-        get.assert_called_once_with(
-            "https://vault.centos.org/centos/", timeout=30
-        )
+        get.return_value = self.make_response(top_data, requests.codes.ok)
+        result = list(finder._get_dirs())
+        # Ensure that only the items we're interested in come back
+        self.assertEqual([top_repos[3], top_repos[1], top_repos[0]], result)
+        get.assert_called_once_with(centos.VAULT, timeout=30)
 
-    def test__get_path(self):
+    def test__get_source_repos(self):
         finder = self.make_finder()
-        data = self.make_index_page_content(finder.name, finder.version)
-        ref = finder._get_path(data)
-        self.assertEqual(f'{finder.name}-{finder.version}.src.rpm', ref)
-
-    def test__get_path_returns_None_if_not_found(self):
-        finder = self.make_finder()
-        data = self.make_index_page_content(
-            self.factory.make_string(), self.factory.make_string()
-        )
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(data, requests.codes.ok)
-        dir_ = self.factory.make_string('8.0') + '/'
-        self.assertIsNone(finder._get_path(dir_))
-
-    def test_find_raises_when_not_found(self):
-        finder = self.make_finder()
-        url = self.factory.make_url()
-        self.patch(finder, '_get_dirs').return_value = ['a']
-        self.patch(finder, '_get_source_dirs_content').return_value = [
-            (url, 'data')
-        ]
-        self.patch(finder, '_get_path').return_value = None
-        with testtools.ExpectedException(exceptions.SourceNotFound):
-            finder.find()
-
-    def test_find_raises_when_download_error(self):
-        finder = self.make_finder()
-        self.patch(requests, 'get').return_value = self.make_response(
-            [], requests.codes.bad_request
-        )
-        with testtools.ExpectedException(exceptions.DownloadError):
-            finder.find()
-
-    def test_find(self):
-        finder = self.make_finder()
-        dir_ = self.factory.make_string('dir')
-        url = self.factory.make_url()
-        ref = self.factory.make_string()
-        self.patch(finder, '_get_dirs').return_value = [dir_]
-        self.patch(finder, '_get_source_dirs_content').return_value = [
-            (url, 'data')
-        ]
-        self.patch(finder, '_get_path').return_value = ref
-
-        disc_source = finder.find()
-        self.assertIsInstance(disc_source, centos.CentosDiscoveredSource)
-        self.assertEqual([f"{url}/{ref}"], disc_source.urls)
-
-    def test_find_calls_get_repo_if_using_fallback_method(self):
-        finder = self.make_finder(version='1.2.3.el8')
-        self.patch(finder, '_get_dirs').return_value = []
-        url = self.factory.make_url()
-        self.patch(finder, '_repo_lookup').return_value = url
-        self.assertEqual(url, finder._find().urls[0])
-
-
-class TestGetDirsScenarios(BaseCentosTest):
-
-    scenarios = [
-        ('6.0', dict(version='6.0', append='.el6')),
-        ('7.0', dict(version='7.0', append='.el7')),
-        ('8.0', dict(version='8.0', append='.el8')),
-    ]
-
-    def test__get_dirs_ignores_dirs_based_on_package_version(self):
-        # If the version has got a string like 'el7' in it, then only look
-        # in dirs starting with a 7. Same for el8, etc.
-        finder = self.make_finder()
-        versions = ['6.0', '7.0', '8.0']
-        data = self.make_top_page_content(versions)
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(data, requests.codes.ok)
-        finder.version += self.append
-        dirs = finder._get_dirs()
-        self.assertEqual([self.version], dirs)
-
-
-class TestGetSourceDirsContentScenarios(BaseCentosTest):
-
-    scenarios = [
-        ('post_v8', dict(release='8.0', packages_dir='SPackages')),
-        ('pre_v8', dict(release='7.1', packages_dir='SPackages')),
-        ('6.1', dict(release='6.1', packages_dir='Packages')),
-        ('6.0', dict(release='6.0', packages_dir='Packages')),
-        ('pre_6.0', dict(release='5.0', packages_dir='Packages')),
-    ]
-
-    def test_get_source_dirs_content(self):
-        finder = self.make_finder()
-        # Ensure irrelevant repo dirs are ignored with the 'bogus' one.
-        repos = ('os/', 'extras/', 'BaseOS/', 'bogus/')
-        expected_repos = ('os/', 'BaseOS/')
-        top_data = self.make_top_page_content(repos)
-        data = self.make_index_page_content(finder.name, finder.version)
-        get = self.patch(requests, 'get')
-        # Set up responses for the top index, and the packages indexes for each
-        # item in repos. The 'extras' repo is a broken one which will get a
-        # 404.
-        get.side_effect = (
-            self.make_response(top_data, requests.codes.ok),
-            self.make_response(data, requests.codes.ok),
-            self.make_response(b'', requests.codes.not_found),
-            self.make_response(data, requests.codes.ok),
-        )
-        dir_ = self.release + '/'
-        # Consume iterator.
-        yielded = [_ for _ in finder._get_source_dirs_content(dir_)]
-
-        # We expect it to spit out pairs of (url, data), where each url is the
-        # path to the eventual packages_dir that contains the package, and data
-        # is the content of the page at that location.
+        dirs = [self.factory.make_string() for _ in range(3)]
+        subdirs = [self.factory.make_string() for _ in range(3)]
+        get_dirs = self.patch(finder, '_get_dirs')
+        get_dirs.return_value = dirs
+        test_url = self.patch(finder, '_test_url')
+        test_url.return_value = True
+        result = finder._get_source_repos(subdirs, False)
         expected = [
-            (
-                f"{centos.VAULT}{dir_}{expected_os_dir}Source/"
-                f"{self.packages_dir}",
-                data,
-            )
-            # Ensure only returned source dirs are considered.
-            for expected_os_dir in expected_repos
+            f"{centos.VAULT}/{dir}/{subdir}/Source/"
+            for dir in dirs
+            for subdir in subdirs
         ]
-        self.assertThat(yielded, SameMembers(expected))
+        self.assertEqual(expected, result)
 
-
-class TestCentosFinderRepoLookup(BaseCentosTest):
-    def make_repo(self, evr, sourcerpm=None, location=None):
-        repo = mock.MagicMock()
-        findall = mock.MagicMock()
-        repo.findall = findall
-        package = mock.MagicMock()
-        package.evr = evr
-        package.sourcerpm = sourcerpm
-        package.location = location
-        findall.return_value = [package]
-        return repo
-
-    def test_returns_None_when_repo_load_fails(self):
+    def test__get_source_repos_optimal(self):
         finder = self.make_finder()
-        self.patch(finder, '_get_repo').return_value = None
-        self.assertIsNone(finder._repo_lookup())
+        dirs = [self.factory.make_string() for _ in range(3)]
+        subdirs = [self.factory.make_string() for _ in range(3)]
+        get_dirs = self.patch(finder, '_get_dirs')
+        get_dirs.return_value = dirs
+        test_url = self.patch(finder, '_test_url')
+        test_url.return_value = True
+        result = finder._get_source_repos(subdirs, True)
+        expected = [
+            f"{centos.VAULT}/{dir}/{subdir}/Source/"
+            for dir in dirs
+            for subdir in (tuple(subdirs) + centos.OPTIMAL_SEARCH)
+        ]
+        self.assertEqual(expected, result)
 
-    def test_returns_None_when_package_not_found_in_repo(self):
-        repo = self.make_repo(evr='')
+    def test__get_binary_repos(self):
         finder = self.make_finder()
-        self.patch(finder, '_get_repo').return_value = repo
-        self.assertIsNone(finder._repo_lookup())
+        dirs = [self.factory.make_string() for _ in range(3)]
+        subdirs = [self.factory.make_string() for _ in range(3)]
+        get_dirs = self.patch(finder, '_get_dirs')
+        get_dirs.return_value = dirs
+        test_url = self.patch(finder, '_test_url')
+        test_url.return_value = True
+        result = finder._get_binary_repos(subdirs, False)
+        expected = [
+            f"{centos.VAULT}/{dir}/{subdir}/x86_64/os/"
+            for dir in dirs
+            for subdir in subdirs
+        ]
+        self.assertEqual(expected, result)
 
-    def test_returns_None_when_source_repo_load_fails(self):
+    def test__get_binary_repos_old_style(self):
         finder = self.make_finder()
-        repo = self.make_repo(
-            evr=finder.version,
-            sourcerpm=f'{finder.name}-{finder.version}.src.rpm',
-        )
-        get_repo = self.patch(finder, '_get_repo')
-        get_repo.side_effect = (repo, None)
-        self.assertIsNone(finder._repo_lookup())
-        self.assertEqual(2, len(get_repo.mock_calls))
+        dirs = [self.factory.make_string() for _ in range(3)]
+        subdirs = [self.factory.make_string() for _ in range(3)]
+        get_dirs = self.patch(finder, '_get_dirs')
+        get_dirs.return_value = dirs
+        test_url = self.patch(finder, '_test_url')
+        test_url.side_effect = itertools.cycle((False, True))
+        result = finder._get_binary_repos(subdirs, False)
+        expected = [
+            f"{centos.VAULT}/{dir}/{subdir}/x86_64/"
+            for dir in dirs
+            for subdir in subdirs
+        ]
+        self.assertEqual(expected, result)
 
-    def test_returns_None_when_source_package_not_found_in_repo(self):
+    def test__get_binary_repos_using_mirror(self):
         finder = self.make_finder()
-        repo = self.make_repo(
-            evr=finder.version,
-            sourcerpm=f'{finder.name}-{finder.version}.src.rpm',
-        )
-        src_repo = self.make_repo(evr='')
-        get_repo = self.patch(finder, '_get_repo')
-        num_source_dirs = len(finder.source_dirs)
-        get_repo.side_effect = (repo, src_repo) * num_source_dirs
-        self.assertIsNone(finder._repo_lookup())
-        self.assertEqual(2 * num_source_dirs, len(get_repo.mock_calls))
+        dirs = [self.factory.make_string() for _ in range(3)]
+        subdirs = [self.factory.make_string() for _ in range(3)]
+        get_dirs = self.patch(finder, '_get_dirs')
+        get_dirs.return_value = dirs
+        test_url = self.patch(finder, '_test_url')
+        test_url.side_effect = itertools.cycle((False, False, True))
+        result = finder._get_binary_repos(subdirs, False)
+        expected = [
+            f"{centos.MIRROR}/{dir}/{subdir}/x86_64/os/"
+            for dir in dirs
+            for subdir in subdirs
+        ]
+        self.assertEqual(expected, result)
 
-    def test_returns_url_when_source_package_is_found(self):
+    def test__get_binary_repos_old_style_using_mirror(self):
         finder = self.make_finder()
-        repo = self.make_repo(
-            evr=finder.version,
-            sourcerpm=f'{finder.name}-{finder.version}.src.rpm',
-        )
-        location = self.factory.make_string('location;')
-        src_repo = self.make_repo(evr=finder.version, location=location)
-        get_repo = self.patch(finder, '_get_repo')
-        get_repo.side_effect = (repo, src_repo)
-        # Will match the first source_dirs entry as we made the fake
-        # repo match right away.
-        self.assertEqual(
-            f'{centos.VAULT}8/{finder.source_dirs[0]}' f'Source/{location}',
-            finder._repo_lookup(),
-        )
+        dirs = [self.factory.make_string() for _ in range(3)]
+        subdirs = [self.factory.make_string() for _ in range(3)]
+        get_dirs = self.patch(finder, '_get_dirs')
+        get_dirs.return_value = dirs
+        test_url = self.patch(finder, '_test_url')
+        test_url.side_effect = itertools.cycle((False, False, False, True))
+        result = finder._get_binary_repos(subdirs, False)
+        expected = [
+            f"{centos.MIRROR}/{dir}/{subdir}/x86_64/"
+            for dir in dirs
+            for subdir in subdirs
+        ]
+        self.assertEqual(expected, result)
 
-    def test__get_repo_returns_None_when_HTTPError(self):
-        url = self.factory.make_url()
-        load = self.patch(centos.repomd, 'load')
-        load.side_effect = urllib.error.HTTPError(
-            url, '404', 'foo', dict(), None
-        )
+    def test__get_binary_repos_optimal(self):
         finder = self.make_finder()
-        repo = finder._get_repo(url)
-        self.assertIsNone(repo)
+        dirs = [self.factory.make_string() for _ in range(3)]
+        subdirs = [self.factory.make_string() for _ in range(3)]
+        get_dirs = self.patch(finder, '_get_dirs')
+        get_dirs.return_value = dirs
+        test_url = self.patch(finder, '_test_url')
+        test_url.return_value = True
+        result = finder._get_binary_repos(subdirs, True)
+        expected = [
+            f"{centos.VAULT}/{dir}/{subdir}/x86_64/os/"
+            for dir in dirs
+            for subdir in (tuple(subdirs) + centos.OPTIMAL_SEARCH)
+        ]
+        self.assertEqual(expected, result)
 
-    def test__get_repo_returns_repo(self):
-        load = self.patch(centos.repomd, 'load')
-        load.return_value = mock.sentinel.REPO
+    def test__get_binary_repos_optimal_old_style(self):
         finder = self.make_finder()
-        url = self.factory.make_url()
-        repo = finder._get_repo(url)
-        load.assert_called_once_with(url)
-        self.assertEqual(repo, mock.sentinel.REPO)
+        dirs = [self.factory.make_string() for _ in range(3)]
+        subdirs = [self.factory.make_string() for _ in range(3)]
+        get_dirs = self.patch(finder, '_get_dirs')
+        get_dirs.return_value = dirs
+        test_url = self.patch(finder, '_test_url')
+        test_url.side_effect = itertools.cycle((False, True))
+        result = finder._get_binary_repos(subdirs, True)
+        expected = [
+            f"{centos.VAULT}/{dir}/{subdir}/x86_64/"
+            for dir in dirs
+            for subdir in (tuple(subdirs) + centos.OPTIMAL_SEARCH)
+        ]
+        self.assertEqual(expected, result)
 
-    def test__get_repo_is_cached(self):
-        load = self.patch(centos.repomd, 'load')
-        url = self.factory.make_url()
+    def test__get_binary_repos_optimal_using_mirror(self):
         finder = self.make_finder()
-        finder._get_repo(url)
-        finder._get_repo(url)
-        load.assert_called_once_with(url)
+        dirs = [self.factory.make_string() for _ in range(3)]
+        subdirs = [self.factory.make_string() for _ in range(3)]
+        get_dirs = self.patch(finder, '_get_dirs')
+        get_dirs.return_value = dirs
+        test_url = self.patch(finder, '_test_url')
+        test_url.side_effect = itertools.cycle((False, False, True))
+        result = finder._get_binary_repos(subdirs, True)
+        expected = [
+            f"{centos.MIRROR}/{dir}/{subdir}/x86_64/os/"
+            for dir in dirs
+            for subdir in (tuple(subdirs) + centos.OPTIMAL_SEARCH)
+        ]
+        self.assertEqual(expected, result)
 
-
-class TestCentosDiscoveredSource(base.TestCase):
-    def make_discovered_source(self, url=None):
-        if url is None:
-            url = self.factory.make_url()
-        return centos.CentosDiscoveredSource([url])
-
-    def test_repr(self):
-        url = self.factory.make_url()
-        cds = self.make_discovered_source(url)
-        self.assertEqual(url, repr(cds))
-
-    def test_make_archive(self):
-        cds = self.make_discovered_source()
-        self.assertEqual(cds.make_archive, cds.remote_url_is_archive)
+    def test__get_binary_repos_optimal_old_style_using_mirror(self):
+        finder = self.make_finder()
+        dirs = [self.factory.make_string() for _ in range(3)]
+        subdirs = [self.factory.make_string() for _ in range(3)]
+        get_dirs = self.patch(finder, '_get_dirs')
+        get_dirs.return_value = dirs
+        test_url = self.patch(finder, '_test_url')
+        test_url.side_effect = itertools.cycle((False, False, False, True))
+        result = finder._get_binary_repos(subdirs, True)
+        expected = [
+            f"{centos.MIRROR}/{dir}/{subdir}/x86_64/"
+            for dir in dirs
+            for subdir in (tuple(subdirs) + centos.OPTIMAL_SEARCH)
+        ]
+        self.assertEqual(expected, result)

--- a/soufi/tests/finders/test_photon_finder.py
+++ b/soufi/tests/finders/test_photon_finder.py
@@ -1,25 +1,31 @@
 # Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
-import urllib
 from unittest import mock
 
 import requests
-import testtools
-from testtools.matchers._basic import SameMembers
 
 from soufi import exceptions
 from soufi.finder import SourceType
-from soufi.finders import photon
+from soufi.finders import photon, yum
 from soufi.testing import base
 
 
 class BasePhotonTest(base.TestCase):
+    def setUp(self):
+        super().setUp()
+        yum.YumFinder._get_repo.cache_clear()
+        yum.YumFinder._get_url.cache_clear()
+
     def make_finder(self, name=None, version=None, **kwargs):
         if name is None:
             name = self.factory.make_string('name')
         if version is None:
             version = self.factory.make_string('version')
+        if 'source_repos' not in kwargs:
+            kwargs['source_repos'] = ['']
+        if 'binary_repos' not in kwargs:
+            kwargs['binary_repos'] = ['']
         return photon.PhotonFinder(name, version, SourceType.os, **kwargs)
 
     def make_response(self, data, code):
@@ -35,276 +41,199 @@ class BasePhotonTest(base.TestCase):
         links = [self.make_href(v) for v in versions]
         return "\n".join(links)
 
-    def make_index_page_content(self, name, version):
-        # Makes something approximating the package index page from
-        # vault.photon.org with our desired package at a random place.
-        random_position = self.factory.randint(1, 8)
-        rows = []
-        for i in range(0, 10):
-            if i == random_position:
-                name_ = name
-                version_ = version
-            else:
-                name_ = self.factory.make_string('name')
-                version_ = self.factory.make_string('version')
-            rows.append(self.make_href(f'{name_}-{version_}.src.rpm'))
-        return b'\n'.join(row.encode('utf8') for row in rows)
-
 
 class TestPhotonFinder(BasePhotonTest):
-    def setUp(self):
-        super().setUp()
-        # Make sure this doesn't interfere with fast lookup tests.
-        self.patch(photon.PhotonFinder, '_repo_lookup').return_value = None
-
-    def test__get_dir(self):
-        version = self.factory.make_string('version') + '.ph3'
-        finder = self.make_finder(version=version)
-        versions = ['1.0', '2.0', '3.0', '4.0', 'ignored']
-        data = self.make_top_page_content(versions)
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(data, requests.codes.ok)
-        dir_ = finder._get_dir()
-        self.assertEqual('3.0', dir_)
-        get.assert_called_once_with(
-            "https://packages.vmware.com/photon/", timeout=30
-        )
-
-    def test__get_dir_raises_on_multiple_answers(self):
-        finder = self.make_finder()
-        data = self.make_top_page_content(['1.0', '2.0'])
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(data, requests.codes.ok)
-        self.assertRaises(exceptions.SourceNotFound, finder._get_dir)
-        get.assert_called_once_with(
-            "https://packages.vmware.com/photon/", timeout=30
-        )
-
-    def test__get_path(self):
-        finder = self.make_finder()
-        data = self.make_index_page_content(finder.name, finder.version)
-        ref = finder._get_path(data)
-        self.assertEqual(f'{finder.name}-{finder.version}.src.rpm', ref)
-
-    def test__get_path_returns_None_if_not_found(self):
-        finder = self.make_finder()
-        data = self.make_index_page_content(
-            self.factory.make_string(), self.factory.make_string()
-        )
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(data, requests.codes.ok)
-        dir_ = self.factory.make_string('8.0') + '/'
-        self.assertIsNone(finder._get_path(dir_))
-
-    def test_find_raises_when_not_found(self):
-        finder = self.make_finder()
-        url = self.factory.make_url()
-        self.patch(finder, '_get_dir').return_value = 'a'
-        self.patch(finder, '_get_source_dirs_content').return_value = [
-            (url, 'data')
-        ]
-        self.patch(finder, '_get_path').return_value = None
-        with testtools.ExpectedException(exceptions.SourceNotFound):
-            finder.find()
-
-    def test_find_raises_when_download_error(self):
-        finder = self.make_finder()
-        self.patch(requests, 'get').return_value = self.make_response(
-            [], requests.codes.bad_request
-        )
-        with testtools.ExpectedException(exceptions.DownloadError):
-            finder.find()
-
     def test_find(self):
         finder = self.make_finder()
-        dir_ = self.factory.make_string('dir')
         url = self.factory.make_url()
-        ref = self.factory.make_string()
-        self.patch(finder, '_get_dir').return_value = dir_
-        self.patch(finder, '_get_source_dirs_content').return_value = [
-            (url, 'data')
-        ]
-        self.patch(finder, '_get_path').return_value = ref
-
+        self.patch(finder, 'get_source_url').return_value = url
         disc_source = finder.find()
-        self.assertIsInstance(disc_source, photon.PhotonDiscoveredSource)
-        self.assertEqual([f"{url}{ref}"], disc_source.urls)
+        self.assertIsInstance(disc_source, yum.YumDiscoveredSource)
+        self.assertEqual([url], disc_source.urls)
 
-    def test_find_calls_get_repo_if_using_fallback_method(self):
-        finder = self.make_finder(version='1.2.3.ph4')
-        url = self.factory.make_url()
-        ref = self.factory.make_string()
-        self.patch(finder, '_get_dir')
-        content = [(url, 'a')]
-        self.patch(finder, '_get_source_dirs_content').return_value = content
-        self.patch(finder, '_repo_lookup').return_value = ref
-        self.assertEqual(f'{url}{ref}', finder._find().urls[0])
+    def test_initializer_finds_repos_when_called_with_no_args(self):
+        name = self.factory.make_string('name')
+        version = self.factory.make_string('version')
+        get_source_repos = self.patch(photon.PhotonFinder, '_get_source_repos')
+        get_binary_repos = self.patch(photon.PhotonFinder, '_get_binary_repos')
+        photon.PhotonFinder(name, version, SourceType.os)
+        get_source_repos.assert_called_once_with()
+        get_binary_repos.assert_called_once_with()
 
-
-class TestGetDirScenarios(BasePhotonTest):
-
-    scenarios = [
-        ('2.0', dict(version='2.0', append='.ph2')),
-        ('3.0', dict(version='3.0', append='.ph3')),
-        ('4.0', dict(version='4.0', append='.ph4')),
-    ]
-
-    def test__get_dir_ignores_dirs_based_on_package_version(self):
-        # If the version has got a string like 'ph2' in it, then only look
-        # in dirs starting with a 2. Same for ph4, etc.
+    def test__get_source_repos(self):
         finder = self.make_finder()
-        versions = ['2.0', '3.0', '4.0']
-        data = self.make_top_page_content(versions)
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(data, requests.codes.ok)
-        finder.version += self.append
-        dir = finder._get_dir()
-        self.assertEqual(self.version, dir)
-
-
-class TestGetSourceDirsContentScenarios(BasePhotonTest):
-    def test_get_source_dirs_content(self):
-        finder = self.make_finder()
-        # Ensure irrelevant repo dirs are ignored with the 'bogus' one.
+        # Ensure irrelevant repo dirs are ignored with the 'bogus' ones.
+        top_repos = ('3.0/', '4.0/')
         repos = (
             '1_srpms_x86_64/',
+            'bogus/',
             '2_srpms_x86_64/',
             '3_srpms_x86_64/',
-            'bogus/',
+            'also_bogus/',
+            '4_srpms_x86_64/',
         )
-        expected_repos = repos[:2]
-        top_data = self.make_top_page_content(repos)
-        data = self.make_index_page_content(finder.name, finder.version)
+        top_data = self.make_top_page_content(top_repos)
+        page1 = self.make_top_page_content(repos[:3])
+        page2 = self.make_top_page_content(repos[3:])
         get = self.patch(requests, 'get')
         # Set up responses for the top index, and the packages indexes for each
-        # item in repos. The '3' repo is a broken one which will get a 404.
+        # item in repos.
         get.side_effect = (
             self.make_response(top_data, requests.codes.ok),
-            self.make_response(data, requests.codes.ok),
-            self.make_response(data, requests.codes.ok),
-            self.make_response(b'', requests.codes.not_found),
+            self.make_response(page1, requests.codes.ok),
+            self.make_response(page2, requests.codes.ok),
         )
-        dir_ = self.factory.make_string()
-        # Consume iterator.
-        yielded = [_ for _ in finder._get_source_dirs_content(dir_)]
-
-        # We expect it to spit out pairs of (url, data), where each url is the
-        # path to the eventual packages_dir that contains the package, and data
-        # is the content of the page at that location.
+        result = finder._get_source_repos()
         expected = [
-            (
-                f"{photon.PHOTON_PACKAGES}{dir_}{expected_os_dir}",
-                data,
-            )
-            # Ensure only returned source dirs are considered.
-            for expected_os_dir in expected_repos
+            photon.PHOTON_PACKAGES + '/' + top_repos[1] + repos[0],
+            photon.PHOTON_PACKAGES + '/' + top_repos[1] + repos[2],
+            photon.PHOTON_PACKAGES + '/' + top_repos[0] + repos[3],
+            photon.PHOTON_PACKAGES + '/' + top_repos[0] + repos[5],
         ]
-        self.assertThat(yielded, SameMembers(expected))
-
-
-class TestPhotonFinderRepoLookup(BasePhotonTest):
-    def make_repo(self, evr, sourcerpm=None, location=None):
-        repo = mock.MagicMock()
-        findall = mock.MagicMock()
-        repo.findall = findall
-        package = mock.MagicMock()
-        package.evr = evr
-        package.sourcerpm = sourcerpm
-        package.location = location
-        findall.return_value = [package]
-        return repo
-
-    def test_returns_None_when_repo_load_fails(self):
-        data = self.make_top_page_content(['updates'])
-        finder = self.make_finder()
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(data, requests.codes.ok)
-        self.patch(finder, '_get_repo').return_value = None
-        self.assertIsNone(finder._repo_lookup(self.factory.make_url()))
-
-    def test_returns_None_when_package_not_found_in_repo(self):
-        repo = self.make_repo(evr='')
-        data = self.make_top_page_content(['updates'])
-        finder = self.make_finder()
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(data, requests.codes.ok)
-        self.patch(finder, '_get_repo').return_value = repo
-        self.assertIsNone(finder._repo_lookup(self.factory.make_url()))
-
-    def test_returns_None_when_source_repo_load_fails(self):
-        finder = self.make_finder()
-        data = self.make_top_page_content(['releases'])
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(data, requests.codes.ok)
-        get_repo = self.patch(finder, '_get_repo')
-        get_repo.return_value = None
-        url = self.factory.make_url()
-        self.assertIsNone(finder._repo_lookup(url))
-        get_repo.assert_called_once_with(url + 'releases')
-
-    def test_returns_None_when_source_package_not_found_in_repo(self):
-        finder = self.make_finder()
-        data = self.make_top_page_content(['releases'])
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(data, requests.codes.ok)
-        repo = self.make_repo(evr=self.factory.make_string())
-        get_repo = self.patch(finder, '_get_repo')
-        get_repo.return_value = repo
-        url = self.factory.make_url()
-        self.assertIsNone(finder._repo_lookup(url))
-        get_repo.assert_called_once_with(url + 'releases')
-
-    def test_returns_url_when_source_package_is_found(self):
-        finder = self.make_finder()
-        data = self.make_top_page_content(['updates'])
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(data, requests.codes.ok)
-        srcrpm = (f'{finder.name}-{finder.version}.src.rpm',)
-        repo = self.make_repo(evr=finder.version, sourcerpm=srcrpm)
-        self.patch(finder, '_get_repo').return_value = repo
-        # Will match the first source_dirs entry as we made the fake
-        # repo match right away.
-        self.assertEqual(srcrpm, finder._repo_lookup(self.factory.make_url()))
-
-    def test__get_repo_returns_None_when_HTTPError(self):
-        url = self.factory.make_url()
-        load = self.patch(photon.repomd, 'load')
-        load.side_effect = urllib.error.HTTPError(
-            url, '404', 'foo', dict(), None
+        self.assertEqual(expected, result)
+        get.assert_has_calls(
+            [
+                mock.call(photon.PHOTON_PACKAGES, timeout=30),
+                mock.call(
+                    photon.PHOTON_PACKAGES + '/' + top_repos[1], timeout=30
+                ),
+                mock.call(
+                    photon.PHOTON_PACKAGES + '/' + top_repos[0], timeout=30
+                ),
+            ]
         )
+
+    def test__get_source_repos_top_level_failure_throws_exception(self):
         finder = self.make_finder()
-        repo = finder._get_repo(url)
-        self.assertIsNone(repo)
+        get = self.patch(requests, 'get')
+        get.return_value = self.make_response(b'', requests.codes.not_found)
+        self.assertRaises(exceptions.DownloadError, finder._get_source_repos)
 
-    def test__get_repo_returns_repo(self):
-        load = self.patch(photon.repomd, 'load')
-        load.return_value = mock.sentinel.REPO
+    def test__get_source_repos_subdir_failure_omits_subdirs(self):
         finder = self.make_finder()
-        url = self.factory.make_url()
-        repo = finder._get_repo(url)
-        load.assert_called_once_with(url)
-        self.assertEqual(repo, mock.sentinel.REPO)
+        top_data = self.make_top_page_content(['1.0/', '2.0/'])
+        data = self.make_top_page_content(['1_srpms_x86_64/'])
+        get = self.patch(requests, 'get')
+        # The first index page listed is actually no good
+        get.side_effect = (
+            self.make_response(top_data, requests.codes.ok),
+            self.make_response(b'', requests.codes.not_found),
+            self.make_response(data, requests.codes.ok),
+        )
+        # We should only have one source repo directory available
+        result = finder._get_source_repos()
+        expected = [f"{photon.PHOTON_PACKAGES}/1.0/1_srpms_x86_64/"]
+        self.assertEqual(expected, result)
+        get.assert_has_calls(
+            [
+                mock.call(photon.PHOTON_PACKAGES, timeout=30),
+                mock.call(photon.PHOTON_PACKAGES + '/2.0/', timeout=30),
+                mock.call(photon.PHOTON_PACKAGES + '/1.0/', timeout=30),
+            ]
+        )
 
-    def test__get_repo_is_cached(self):
-        load = self.patch(photon.repomd, 'load')
-        url = self.factory.make_url()
+    def test__get_binary_repos(self):
         finder = self.make_finder()
-        finder._get_repo(url)
-        finder._get_repo(url)
-        load.assert_called_once_with(url)
+        top_repos = ('3.0/', '4.0/')
+        repos = (
+            '1_srpms_x86_64/',
+            'bogus/',
+            '2_packages_x86_64/',
+            '3_updates_x86_64/',
+            'also_bogus/',
+            '4_srpms_x86_64/',
+        )
+        top_data = self.make_top_page_content(top_repos)
+        page1 = self.make_top_page_content(repos[:3])
+        page2 = self.make_top_page_content(repos[3:])
+        get = self.patch(requests, 'get')
+        # Set up responses for the top index, and the packages indexes for each
+        # item in repos.
+        get.side_effect = (
+            self.make_response(top_data, requests.codes.ok),
+            self.make_response(page1, requests.codes.ok),
+            self.make_response(page2, requests.codes.ok),
+        )
+        expected = [
+            photon.PHOTON_PACKAGES + '/' + top_repos[1] + repos[2],
+            photon.PHOTON_PACKAGES + '/' + top_repos[0] + repos[3],
+        ]
+        result = finder._get_binary_repos()
+        self.assertEqual(expected, result)
+        get.assert_has_calls(
+            [
+                mock.call(photon.PHOTON_PACKAGES, timeout=30),
+                mock.call(
+                    photon.PHOTON_PACKAGES + '/' + top_repos[1], timeout=30
+                ),
+                mock.call(
+                    photon.PHOTON_PACKAGES + '/' + top_repos[0], timeout=30
+                ),
+            ]
+        )
 
+    def test__get_binary_repos_top_level_failure_throws_exception(self):
+        finder = self.make_finder()
+        get = self.patch(requests, 'get')
+        get.return_value = self.make_response(b'', requests.codes.not_found)
+        self.assertRaises(exceptions.DownloadError, finder._get_binary_repos)
 
-class TestPhotonDiscoveredSource(base.TestCase):
-    def make_discovered_source(self, url=None):
-        if url is None:
-            url = self.factory.make_url()
-        return photon.PhotonDiscoveredSource([url])
+    def test__get_binary_repos_subdir_failure_omits_subdirs(self):
+        finder = self.make_finder()
+        top_data = self.make_top_page_content(['6.0/', '9.0/'])
+        data = self.make_top_page_content(['1_base_x86_64'])
+        get = self.patch(requests, 'get')
+        # The first index page listed is actually no good
+        get.side_effect = (
+            self.make_response(top_data, requests.codes.ok),
+            self.make_response(b'', requests.codes.not_found),
+            self.make_response(data, requests.codes.ok),
+        )
+        # We should only have one source repo directory available
+        result = finder._get_binary_repos()
+        expected = [f"{photon.PHOTON_PACKAGES}/6.0/1_base_x86_64"]
+        self.assertEqual(expected, result)
+        get.assert_has_calls(
+            [
+                mock.call(photon.PHOTON_PACKAGES, timeout=30),
+                mock.call(photon.PHOTON_PACKAGES + '/9.0/', timeout=30),
+                mock.call(photon.PHOTON_PACKAGES + '/6.0/', timeout=30),
+            ]
+        )
 
-    def test_repr(self):
-        url = self.factory.make_url()
-        pds = self.make_discovered_source(url)
-        self.assertEqual(url, repr(pds))
+    def test__walk_source_repos(self):
+        name = self.factory.make_string('name')
+        version = self.factory.make_string('ver')
+        urls = [self.factory.make_url() for _ in range(10)]
+        finder = self.make_finder(source_repos=urls)
+        test_url = self.patch(finder, '_test_url')
+        test_url.side_effect = (False, False, True)
+        # Ensure that it doesn't run the entire list once one has been found
+        self.assertEqual(
+            f"{urls[2]}/{name}-{version}.src.rpm",
+            finder._walk_source_repos(name, version),
+        )
+        test_url.assert_has_calls(
+            [mock.call(f"{url}/{name}-{version}.src.rpm") for url in urls[:3]]
+        )
 
-    def test_make_archive(self):
-        pds = self.make_discovered_source()
-        self.assertEqual(pds.make_archive, pds.remote_url_is_archive)
+    def test__walk_source_repos_no_match_returns_none(self):
+        name = self.factory.make_string('name')
+        version = self.factory.make_string('ver')
+        urls = [self.factory.make_url() for _ in range(3)]
+        finder = self.make_finder(source_repos=urls)
+        test_url = self.patch(finder, '_test_url')
+        test_url.return_value = False
+        self.assertIsNone(finder._walk_source_repos(name, version))
+        test_url.assert_has_calls(
+            [mock.call(f"{url}/{name}-{version}.src.rpm") for url in urls]
+        )
+
+    def test__walk_source_repos_one_arg_short_circuits(self):
+        arg = self.factory.make_string()
+        # Deliberately setup the mock wrong, this way if future code breaks
+        # the short-circuit behaviour this will throw errors
+        finder = self.make_finder(source_repos=[1, 2, 3])
+        test_url = self.patch(finder, '_test_url')
+        self.assertIsNone(finder._walk_source_repos(arg))
+        test_url.assert_not_called()

--- a/soufi/tests/finders/test_rhel_finder.py
+++ b/soufi/tests/finders/test_rhel_finder.py
@@ -10,7 +10,7 @@ class BaseRHELTest(base.TestCase):
     def setUp(self):
         super().setUp()
         yum.YumFinder._get_repo.cache_clear()
-        yum.YumFinder._get_url.cache_clear()
+        yum.YumFinder.get_url.cache_clear()
 
     def make_finder(self, name=None, version=None, **kwargs):
         if name is None:

--- a/soufi/tests/finders/test_rhel_finder.py
+++ b/soufi/tests/finders/test_rhel_finder.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# All rights reserved.
+
+from soufi.finder import SourceType
+from soufi.finders import rhel, yum
+from soufi.testing import base
+
+
+class BaseRHELTest(base.TestCase):
+    def setUp(self):
+        super().setUp()
+        yum.YumFinder._get_repo.cache_clear()
+        yum.YumFinder._get_url.cache_clear()
+
+    def make_finder(self, name=None, version=None, **kwargs):
+        if name is None:
+            name = self.factory.make_string('name')
+        if version is None:
+            version = self.factory.make_string('version')
+        if 'source_repos' not in kwargs:
+            kwargs['source_repos'] = ['']
+        if 'binary_repos' not in kwargs:
+            kwargs['binary_repos'] = ['']
+        return rhel.RHELFinder(name, version, SourceType.os, **kwargs)
+
+    def test_find(self):
+        finder = self.make_finder()
+        url = self.factory.make_url()
+        self.patch(finder, 'get_source_url').return_value = url
+        disc_source = finder.find()
+        self.assertIsInstance(disc_source, yum.YumDiscoveredSource)
+        self.assertEqual([url], disc_source.urls)
+
+    def test_initializer_uses_defaults_when_called_with_no_args(self):
+        name = self.factory.make_string('name')
+        version = self.factory.make_string('version')
+        finder = rhel.RHELFinder(name, version, SourceType.os)
+        expected_source = [
+            f"{rhel.DEFAULT_REPO}/{dir}/source/SRPMS"
+            for dir in rhel.RHELFinder.default_search_dirs
+        ]
+        expected_binary = [
+            f"{rhel.DEFAULT_REPO}/{dir}/os"
+            for dir in rhel.RHELFinder.default_search_dirs
+        ]
+        self.assertEqual(expected_source, finder.source_repos)
+        self.assertEqual(expected_binary, finder.binary_repos)

--- a/soufi/tests/finders/test_yum_finder.py
+++ b/soufi/tests/finders/test_yum_finder.py
@@ -1,0 +1,338 @@
+# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# All rights reserved.
+import string
+import urllib
+from itertools import repeat
+from unittest import mock
+
+import repomd
+import requests
+from testtools.matchers import Equals
+
+import soufi.exceptions
+from soufi.finder import SourceType
+from soufi.finders import yum
+from soufi.testing import base
+
+
+class YumFinderImpl(yum.YumFinder):
+    """An implementation for testing the YumFimder ABC."""
+
+    distro = 'yum'
+
+    def _get_source_repos(self):
+        return ()
+
+    def _get_binary_repos(self):
+        return ()
+
+
+class BaseYumTest(base.TestCase):
+    class FakePackage:
+        vr = None
+        evr = None
+        location = None
+        sourcerpm = None
+
+        def __init__(self, vr=None, evr=None, location=None, sourcerpm=None):
+            if vr is None:
+                vr = BaseYumTest.factory.make_semver()
+            if evr is None:
+                evr = BaseYumTest.factory.make_semver()
+            if location is None:
+                location = BaseYumTest.factory.make_string()
+            if sourcerpm is None:
+                sourcerpm = BaseYumTest.factory.make_string()
+
+            self.vr = vr
+            self.evr = evr
+            self.location = location
+            self.sourcerpm = sourcerpm
+
+    def make_finder(self, name=None, version=None, **kwargs):
+        if name is None:
+            name = self.factory.make_string('name')
+        if version is None:
+            version = self.factory.make_string('version')
+        if 'source_repos' not in kwargs:
+            kwargs['source_repos'] = []
+        if 'binary_repos' not in kwargs:
+            kwargs['binary_repos'] = []
+        return YumFinderImpl(name, version, SourceType.os, **kwargs)
+
+    def make_response(self, data, code):
+        fake_response = mock.MagicMock()
+        fake_response.content = data
+        fake_response.status_code = code
+        return fake_response
+
+    def make_package(self, n=None, e=None, v=None, r=None, a=None, epoch=None):
+        # `epoch` is `name` or `ver`, to denote where to inject it
+        random_packagename = map(
+            self.factory.random_choice,
+            repeat(string.ascii_letters + string.digits + "_-"),
+        )
+        if n is None:
+            n = self.factory.make_string(charset=random_packagename)
+        if e is None:
+            e = self.factory.randint(0, 10)
+        if v is None:
+            v = self.factory.make_semver()
+        if r is None:
+            r = self.factory.randint(0, 100)
+        if a is None:
+            a = self.factory.make_string()
+        if epoch == 'ver':
+            v = f"{e}:{v}"
+        elif epoch == 'name':
+            n = f"{e}:{n}"
+
+        # Package names always end in `.rpm` for testing
+        return f"{n}-{v}-{r}.{a}.rpm"
+
+
+class TestYumFinder(BaseYumTest):
+    def test_find(self):
+        finder = self.make_finder()
+        url = self.factory.make_url()
+        self.patch(finder, 'get_source_url').return_value = url
+        disc_source = finder.find()
+        self.assertIsInstance(disc_source, yum.YumDiscoveredSource)
+        self.assertEqual([url], disc_source.urls)
+
+    def test_get_source_url(self):
+        name = self.factory.make_string()
+        url = self.factory.make_url()
+        finder = self.make_finder(name=name)
+        walk_src = self.patch(finder, '_walk_source_repos')
+        walk_src.return_value = url
+        self.patch(finder, '_test_url').return_value = True
+        self.assertEqual(url, finder.get_source_url())
+        walk_src.assert_called_once_with(name)
+
+    def test_get_source_url_binary_package(self):
+        name = self.factory.make_string()
+        ver = self.factory.make_semver(extra=self.factory.make_string("-"))
+        url = self.factory.make_url()
+        finder = self.make_finder(name=name, version=ver)
+        walk_src = self.patch(finder, '_walk_source_repos')
+        walk_src.side_effect = (None, url)
+        walk_binary = self.patch(finder, '_walk_binary_repos')
+        walk_binary.return_value = name, ver
+        self.patch(finder, '_test_url').return_value = True
+        self.assertEqual(url, finder.get_source_url())
+        walk_binary.assert_called_once_with(name)
+        walk_src.assert_has_calls([mock.call(name), mock.call(name, ver)])
+
+    def test_get_source_url_raises_on_no_source(self):
+        name = self.factory.make_string()
+        finder = self.make_finder(name=name)
+        walk_src = self.patch(finder, '_walk_source_repos')
+        walk_src.return_value = None
+        self.assertRaises(
+            soufi.exceptions.SourceNotFound, finder.get_source_url
+        )
+        walk_src.assert_called_once_with(name)
+
+    def test_get_source_url_raises_on_no_source_2(self):
+        name = self.factory.make_string()
+        finder = self.make_finder(name=name)
+        walk_src = self.patch(finder, '_walk_source_repos')
+        walk_src.return_value = None
+        walk_binary = self.patch(finder, '_walk_binary_repos')
+        walk_binary.return_value = (name, None)
+        self.assertRaises(
+            soufi.exceptions.SourceNotFound, finder.get_source_url
+        )
+        walk_binary.assert_called_once_with(name)
+        walk_src.assert_has_calls([mock.call(name), mock.call(name, None)])
+
+    def test_get_source_url_raises_on_invalid_source(self):
+        name = self.factory.make_string()
+        url = self.factory.make_url()
+        finder = self.make_finder(name=name)
+        walk_src = self.patch(finder, '_walk_source_repos')
+        walk_src.return_value = url
+        self.patch(finder, '_test_url').return_value = False
+        self.assertRaises(
+            soufi.exceptions.SourceNotFound, finder.get_source_url
+        )
+        walk_src.assert_called_once_with(name)
+
+    def test__walk_source_repos(self):
+        src = [self.factory.make_url(), self.factory.make_url()]
+        bin = [self.factory.make_url(), self.factory.make_url()]
+        finder = self.make_finder(source_repos=src, binary_repos=bin)
+        repo = mock.MagicMock()
+        repo.baseurl = self.factory.make_url()
+        package = self.FakePackage(vr=finder.version)
+        repo.findall.return_value = [package]
+        self.patch(finder, '_get_repo').side_effect = (None, repo)
+        self.patch(finder, '_test_url').return_value = False
+        url = finder._walk_source_repos(finder.name)
+        self.assertEqual(repo.baseurl + package.location, url)
+
+    def test__walk_source_repos_different_version_hit(self):
+        src = [self.factory.make_url()]
+        bin = [self.factory.make_url()]
+        finder = self.make_finder(source_repos=src, binary_repos=bin)
+        repo = mock.MagicMock()
+        repo.baseurl = self.factory.make_url()
+        package = self.FakePackage()
+        repo.findall.return_value = [package]
+        self.patch(finder, '_get_repo').return_value = repo
+        self.patch(finder, '_test_url').return_value = True
+        url = finder._walk_source_repos(finder.name)
+        self.assertEqual(repo.baseurl + package.location, url)
+
+    def test__walk_source_repos_different_version_miss(self):
+        src = [self.factory.make_url()]
+        bin = [self.factory.make_url()]
+        finder = self.make_finder(source_repos=src, binary_repos=bin)
+        repo = mock.MagicMock()
+        package = self.FakePackage()
+        repo.findall.return_value = [package]
+        self.patch(finder, '_get_repo').return_value = repo
+        self.patch(finder, '_test_url').return_value = False
+        url = finder._walk_source_repos(finder.name)
+        self.assertIsNone(url)
+
+    def test__walk_binary_repos(self):
+        src = [self.factory.make_url(), self.factory.make_url()]
+        bin = [self.factory.make_url(), self.factory.make_url()]
+        finder = self.make_finder(source_repos=src, binary_repos=bin)
+        repo = mock.MagicMock()
+        repo.baseurl = self.factory.make_url()
+        n = self.factory.make_string()
+        v = self.factory.make_semver()
+        r = self.factory.randint(0, 100)
+        srcrpm = self.make_package(n=n, v=v, r=r)
+        package = self.FakePackage(vr=finder.version, sourcerpm=srcrpm)
+        repo.findall.return_value = [package]
+        self.patch(finder, '_get_repo').side_effect = (None, repo)
+        name, version = finder._walk_binary_repos(finder.name)
+        self.expectThat(name, Equals(n))
+        self.expectThat(version, Equals(f"{v}-{r}"))
+
+    def test__walk_binary_repos_no_sourcerpm(self):
+        src = [self.factory.make_url()]
+        bin = [self.factory.make_url()]
+        finder = self.make_finder(source_repos=src, binary_repos=bin)
+        repo = mock.MagicMock()
+        package = self.FakePackage(vr=finder.version, sourcerpm='')
+        repo.findall.return_value = [package]
+        self.patch(finder, '_get_repo').return_value = repo
+        name, version = finder._walk_binary_repos(finder.name)
+        self.assertIsNone(name)
+        self.assertIsNone(version)
+
+    def test__walk_binary_repos_different_name_multiple_versions(self):
+        src = [self.factory.make_url()]
+        bin = [self.factory.make_url()]
+        finder = self.make_finder(source_repos=src, binary_repos=bin)
+        repo = mock.MagicMock()
+        package = self.FakePackage()
+        repo.findall.return_value = [package, package]
+        self.patch(finder, '_get_repo').return_value = repo
+        name, version = finder._walk_binary_repos(finder.name)
+        self.assertIsNone(name)
+        self.assertIsNone(version)
+
+    def test__walk_binary_repos_different_name_different_version(self):
+        src = [self.factory.make_url()]
+        bin = [self.factory.make_url()]
+        finder = self.make_finder(source_repos=src, binary_repos=bin)
+        repo = mock.MagicMock()
+        n = self.factory.make_string()
+        v = self.factory.make_semver()
+        r = self.factory.randint(0, 100)
+        srcrpm = self.make_package(n=n, v=v, r=r)
+        package = self.FakePackage(sourcerpm=srcrpm)
+        repo.findall.return_value = [package]
+        self.patch(finder, '_get_repo').return_value = repo
+        name, version = finder._walk_binary_repos(finder.name)
+        self.expectThat(name, Equals(n))
+        self.expectThat(version, Equals(f"{v}-{r}"))
+
+
+class TestYumFinderHelpers(BaseYumTest):
+    def test__nevra_or_none_returns_nevra(self):
+        name = self.factory.make_string()
+        ver = self.factory.make_semver()
+        rel = self.factory.randint(0, 100)
+        pkg = mock.MagicMock()
+        pkg.sourcerpm = self.make_package(n=name, v=ver, r=rel)
+        finder = self.make_finder()
+        self.assertEqual((name, f"{ver}-{rel}"), finder._nevra_or_none(pkg))
+
+    def test__nevra_or_none_returns_none(self):
+        package = mock.MagicMock()
+        package.sourcerpm = ''
+        finder = self.make_finder()
+        self.assertEqual((None, None), finder._nevra_or_none(package))
+
+    def test__get_repo_returns_none(self):
+        url = self.factory.make_url()
+        rmd = self.patch(repomd, 'load')
+        rmd.side_effect = urllib.error.HTTPError(None, None, None, None, None)
+        finder = self.make_finder()
+        self.assertIsNone(finder._get_repo(url))
+
+    def test__get_nevra(self):
+        filename = self.make_package()
+        finder = self.make_finder()
+        nevra = finder._get_nevra(filename)
+        reassembled = "{name}-{ver}-{rel}.{arch}.rpm".format(**nevra)
+        self.assertEqual(filename, reassembled)
+
+    def test__get_nevra_epoch_in_ver(self):
+        e = self.factory.randint(0, 10)
+        filename = self.make_package(e=e, epoch='ver')
+        finder = self.make_finder()
+        nevra = finder._get_nevra(filename)
+        reassembled = "{name}-{epoch}:{ver}-{rel}.{arch}.rpm".format(**nevra)
+        self.assertEqual(filename, reassembled)
+
+    def test__get_nevra_epoch_in_name(self):
+        e = self.factory.randint(0, 10)
+        filename = self.make_package(e=e, epoch='name')
+        finder = self.make_finder()
+        nevra = finder._get_nevra(filename)
+        reassembled = "{epoch}:{name}-{ver}-{rel}.{arch}.rpm".format(**nevra)
+        self.assertEqual(filename, reassembled)
+
+    def test__test_url_true(self):
+        url = self.factory.make_url()
+        fake_req = self.patch(requests, 'head')
+        fake_req.return_value = self.make_response('', requests.codes.ok)
+        finder = self.make_finder()
+        self.assertTrue(finder._test_url(url))
+
+    def test__test_url_false(self):
+        url = self.factory.make_url()
+        fake_req = self.patch(requests, 'head')
+        fake_req.return_value = self.make_response('', requests.codes.teapot)
+        finder = self.make_finder()
+        self.assertFalse(finder._test_url(url))
+
+    def test__test_url_timeout(self):
+        url = self.factory.make_url()
+        self.patch(requests, 'head').side_effect = requests.exceptions.Timeout
+        finder = self.make_finder()
+        self.assertFalse(finder._test_url(url))
+
+
+class TestYumsDiscoveredSource(base.TestCase):
+    def make_discovered_source(self, url=None):
+        if url is None:
+            url = self.factory.make_url()
+        return yum.YumDiscoveredSource([url])
+
+    def test_repr(self):
+        url = self.factory.make_url()
+        yds = self.make_discovered_source(url)
+        self.assertEqual(url, repr(yds))
+
+    def test_make_archive(self):
+        yds = self.make_discovered_source()
+        self.assertEqual(yds.make_archive, yds.remote_url_is_archive)

--- a/soufi/tests/finders/test_yum_finder.py
+++ b/soufi/tests/finders/test_yum_finder.py
@@ -20,10 +20,10 @@ class YumFinderImpl(yum.YumFinder):
 
     distro = 'yum'
 
-    def _get_source_repos(self):
+    def get_source_repos(self):
         return ()
 
-    def _get_binary_repos(self):
+    def get_binary_repos(self):
         return ()
 
 
@@ -106,7 +106,7 @@ class TestYumFinder(BaseYumTest):
         finder = self.make_finder(name=name)
         walk_src = self.patch(finder, '_walk_source_repos')
         walk_src.return_value = url
-        self.patch(finder, '_test_url').return_value = True
+        self.patch(finder, 'test_url').return_value = True
         self.assertEqual(url, finder.get_source_url())
         walk_src.assert_called_once_with(name)
 
@@ -119,7 +119,7 @@ class TestYumFinder(BaseYumTest):
         walk_src.side_effect = (None, url)
         walk_binary = self.patch(finder, '_walk_binary_repos')
         walk_binary.return_value = name, ver
-        self.patch(finder, '_test_url').return_value = True
+        self.patch(finder, 'test_url').return_value = True
         self.assertEqual(url, finder.get_source_url())
         walk_binary.assert_called_once_with(name)
         walk_src.assert_has_calls([mock.call(name), mock.call(name, ver)])
@@ -153,7 +153,7 @@ class TestYumFinder(BaseYumTest):
         finder = self.make_finder(name=name)
         walk_src = self.patch(finder, '_walk_source_repos')
         walk_src.return_value = url
-        self.patch(finder, '_test_url').return_value = False
+        self.patch(finder, 'test_url').return_value = False
         self.assertRaises(
             soufi.exceptions.SourceNotFound, finder.get_source_url
         )
@@ -168,7 +168,7 @@ class TestYumFinder(BaseYumTest):
         package = self.FakePackage(vr=finder.version)
         repo.findall.return_value = [package]
         self.patch(finder, '_get_repo').side_effect = (None, repo)
-        self.patch(finder, '_test_url').return_value = False
+        self.patch(finder, 'test_url').return_value = False
         url = finder._walk_source_repos(finder.name)
         self.assertEqual(repo.baseurl + package.location, url)
 
@@ -181,7 +181,7 @@ class TestYumFinder(BaseYumTest):
         package = self.FakePackage()
         repo.findall.return_value = [package]
         self.patch(finder, '_get_repo').return_value = repo
-        self.patch(finder, '_test_url').return_value = True
+        self.patch(finder, 'test_url').return_value = True
         url = finder._walk_source_repos(finder.name)
         self.assertEqual(repo.baseurl + package.location, url)
 
@@ -193,7 +193,7 @@ class TestYumFinder(BaseYumTest):
         package = self.FakePackage()
         repo.findall.return_value = [package]
         self.patch(finder, '_get_repo').return_value = repo
-        self.patch(finder, '_test_url').return_value = False
+        self.patch(finder, 'test_url').return_value = False
         url = finder._walk_source_repos(finder.name)
         self.assertIsNone(url)
 
@@ -306,20 +306,20 @@ class TestYumFinderHelpers(BaseYumTest):
         fake_req = self.patch(requests, 'head')
         fake_req.return_value = self.make_response('', requests.codes.ok)
         finder = self.make_finder()
-        self.assertTrue(finder._test_url(url))
+        self.assertTrue(finder.test_url(url))
 
     def test__test_url_false(self):
         url = self.factory.make_url()
         fake_req = self.patch(requests, 'head')
         fake_req.return_value = self.make_response('', requests.codes.teapot)
         finder = self.make_finder()
-        self.assertFalse(finder._test_url(url))
+        self.assertFalse(finder.test_url(url))
 
     def test__test_url_timeout(self):
         url = self.factory.make_url()
         self.patch(requests, 'head').side_effect = requests.exceptions.Timeout
         finder = self.make_finder()
-        self.assertFalse(finder._test_url(url))
+        self.assertFalse(finder.test_url(url))
 
 
 class TestYumsDiscoveredSource(base.TestCase):

--- a/soufi/tests/functional/test_functional.py
+++ b/soufi/tests/functional/test_functional.py
@@ -21,3 +21,41 @@ class FunctionalFinderTests(testtools.TestCase):
         url = 'https://packages.vmware.com/photon/4.0/photon_srpms_4.0_x86_64/curl-7.75.0-2.ph4.src.rpm'  # noqa: E501
         result = photon.find()
         self.assertEqual([url], result.urls)
+
+    def test_find_centos_binary_from_source(self):
+        # Test finding sources for binary packages with entirely different
+        # names/versions.
+        centos = finder.factory(
+            'centos',
+            name='device-mapper-libs',
+            version='1.02.175-5.el8',
+            s_type=SourceType.os,
+        )
+        url = 'https://vault.centos.org/centos/8.4.2105/BaseOS/Source/SPackages/lvm2-2.03.11-5.el8.src.rpm'  # noqa: E501
+        result = centos.find()
+        self.assertEqual([url], result.urls)
+
+    def test_find_centos_binary_from_source_epoch(self):
+        # Ibid, but with the epoch included with the version
+        centos = finder.factory(
+            'centos',
+            name='device-mapper-libs',
+            version='8:1.02.175-5.el8',
+            s_type=SourceType.os,
+        )
+        url = 'https://vault.centos.org/centos/8.4.2105/BaseOS/Source/SPackages/lvm2-2.03.11-5.el8.src.rpm'  # noqa: E501
+        result = centos.find()
+        self.assertEqual([url], result.urls)
+
+    def test_find_centos_binary_from_source_epoch_no_vault(self):
+        # Ibid, but with a binary package not tracked in vault.  This test
+        # will need updating if/when 7.9.2009 eventually gets vaulted.
+        centos = finder.factory(
+            'centos',
+            name='bind-license',
+            version='32:9.11.4-26.P2.el7',
+            s_type=SourceType.os,
+        )
+        url = 'https://vault.centos.org/centos/7.9.2009/os/Source/SPackages/bind-9.11.4-26.P2.el7.src.rpm'  # noqa: E501
+        result = centos.find()
+        self.assertEqual([url], result.urls)

--- a/soufi/tests/functional/test_functional.py
+++ b/soufi/tests/functional/test_functional.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# All rights reserved.
+
+import testtools
+
+from soufi import finder
+from soufi.finder import SourceType
+
+
+class FunctionalFinderTests(testtools.TestCase):
+    def setUp(self):
+        self.skipTest("functional tests disabled for unit test runs")
+
+    def test_find_photon_superseded_package(self):
+        photon = finder.factory(
+            'photon',
+            name='curl-libs',
+            version='7.75.0-2.ph4',
+            s_type=SourceType.os,
+        )
+        url = 'https://packages.vmware.com/photon/4.0/photon_srpms_4.0_x86_64/curl-7.75.0-2.ph4.src.rpm'  # noqa: E501
+        result = photon.find()
+        self.assertEqual([url], result.urls)

--- a/soufi/tests/functional/test_functional.py
+++ b/soufi/tests/functional/test_functional.py
@@ -59,3 +59,28 @@ class FunctionalFinderTests(testtools.TestCase):
         url = 'https://vault.centos.org/centos/7.9.2009/os/Source/SPackages/bind-9.11.4-26.P2.el7.src.rpm'  # noqa: E501
         result = centos.find()
         self.assertEqual([url], result.urls)
+
+    def test_find_rhel_binary_from_source(self):
+        # Test finding sources for binary packages with entirely different
+        # names/versions.
+        rhel = finder.factory(
+            'rhel',
+            name='vim-minimal',
+            version='7.4.629-8.el7_9',
+            s_type=SourceType.os,
+        )
+        url = 'https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/x86_64/source/SRPMS/Packages/v/vim-7.4.629-8.el7_9.src.rpm'  # noqa: E501
+        result = rhel.find()
+        self.assertEqual([url], result.urls)
+
+    def test_find_rhel_binary_from_source_epoch(self):
+        # Ibid, but with the epoch included with the version
+        rhel = finder.factory(
+            'rhel',
+            name='vim-minimal',
+            version='2:7.4.629-8.el7_9',
+            s_type=SourceType.os,
+        )
+        url = 'https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/x86_64/source/SRPMS/Packages/v/vim-7.4.629-8.el7_9.src.rpm'  # noqa: E501
+        result = rhel.find()
+        self.assertEqual([url], result.urls)

--- a/soufi/tests/test_factory.py
+++ b/soufi/tests/test_factory.py
@@ -35,6 +35,7 @@ class TestFinderFactory(base.TestCase):
             'npm',
             'photon',
             'python',
+            'rhel',
             'ubuntu',
         ]
         self.assertListEqual(expected, factory.supported_types)


### PR DESCRIPTION
Oh boy, this one is a **MASSIVE** amount of changes, and will likely merit much discussion, as many of the decisions that went into this were made unilaterally and with zero input from anyone.

### Create a new common `YumFinder` class

This creates a new, common finder for all Yum-based distros.  The "fast lookup" patterns have been completely discarded in favour of "fuzzy" repomd lookups, with verification via HTTP `HEAD` requests.

These finders must be initialized with a canonical search list of repository URLs containing `repodata/repomd.xml` files.  The intention is for sub-classes of this finder to provide helper methods to fill out sensible default search directories, while also allowing for users to provide their own lists (e.g., for an internal-only mirror of packages)

### Refactor Yum-based finders as a subclasses of `YumFinder`

All of the previously-custom XPath searching code is now relegated to building search lists to feed the initializer in a default configuration.  This makes such things far more palatable, since by design SouFi will only try to make sense out of HTML tag soup when talking to well-known providers (i.e., not local mirrors with god-knows-what index modes enabled)

### Adds functional tests

A very (**VERY**) small subset of functionality is under test from this, mostly to demonstrate real-world improvements where these finders can locate sources the previous versions cannot.  They are disabled by default.

Fixes Issue #9 
Fixes Issue #10 
Fixes Issue #11 