### PR TITLE
Simplify YumFinder; Everything is a generator

### DIFF
--- a/soufi/finders/photon.py
+++ b/soufi/finders/photon.py
@@ -62,7 +62,7 @@ class PhotonFinder(yum_finder.YumFinder):
 
         # Re-assemble a source package name, and try to fetch it from all
         # the source repos.  This is startlingly effective.
-        for repo in self.source_repos:
+        for repo in self.generate_source_repos():
             url = f"{repo.rstrip('/')}/{name}-{version}.src.rpm"
             if self.test_url(url):
                 return url

--- a/soufi/finders/rhel.py
+++ b/soufi/finders/rhel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2022 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 import soufi.finders.yum as yum_finder
@@ -33,10 +33,9 @@ class RHELFinder(yum_finder.YumFinder):
     )
 
     def get_source_repos(self):
-        return [
-            f"{DEFAULT_REPO}/{dir}/source/SRPMS"
-            for dir in self.default_search_dirs
-        ]
+        for dir in self.default_search_dirs:
+            yield f"{DEFAULT_REPO}/{dir}/source/SRPMS"
 
     def get_binary_repos(self):
-        return [f"{DEFAULT_REPO}/{dir}/os" for dir in self.default_search_dirs]
+        for dir in self.default_search_dirs:
+            yield f"{DEFAULT_REPO}/{dir}/os"

--- a/soufi/tests/finders/test_photon_finder.py
+++ b/soufi/tests/finders/test_photon_finder.py
@@ -51,15 +51,6 @@ class TestPhotonFinder(BasePhotonTest):
         self.assertIsInstance(disc_source, yum.YumDiscoveredSource)
         self.assertEqual([url], disc_source.urls)
 
-    def test_initializer_finds_repos_when_called_with_no_args(self):
-        name = self.factory.make_string('name')
-        version = self.factory.make_string('version')
-        get_source_repos = self.patch(photon.PhotonFinder, 'get_source_repos')
-        get_binary_repos = self.patch(photon.PhotonFinder, 'get_binary_repos')
-        photon.PhotonFinder(name, version, SourceType.os)
-        get_source_repos.assert_called_once_with()
-        get_binary_repos.assert_called_once_with()
-
     def test__get_source_repos(self):
         finder = self.make_finder()
         # Ensure irrelevant repo dirs are ignored with the 'bogus' ones.

--- a/soufi/tests/finders/test_rhel_finder.py
+++ b/soufi/tests/finders/test_rhel_finder.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
+from testtools.matchers import SameMembers
 
 from soufi.finder import SourceType
 from soufi.finders import rhel, yum
@@ -31,7 +32,7 @@ class BaseRHELTest(base.TestCase):
         self.assertIsInstance(disc_source, yum.YumDiscoveredSource)
         self.assertEqual([url], disc_source.urls)
 
-    def test_initializer_uses_defaults_when_called_with_no_args(self):
+    def test_default_repos(self):
         name = self.factory.make_string('name')
         version = self.factory.make_string('version')
         finder = rhel.RHELFinder(name, version, SourceType.os)
@@ -43,5 +44,9 @@ class BaseRHELTest(base.TestCase):
             f"{rhel.DEFAULT_REPO}/{dir}/os"
             for dir in rhel.RHELFinder.default_search_dirs
         ]
-        self.assertEqual(expected_source, finder.source_repos)
-        self.assertEqual(expected_binary, finder.binary_repos)
+        self.assertThat(
+            finder.get_source_repos(), SameMembers(expected_source)
+        )
+        self.assertThat(
+            finder.get_binary_repos(), SameMembers(expected_binary)
+        )

--- a/soufi/tests/finders/test_yum_finder.py
+++ b/soufi/tests/finders/test_yum_finder.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import repomd
 import requests
-from testtools.matchers import Equals
+from testtools.matchers import Equals, SameMembers
 
 import soufi.exceptions
 from soufi.finder import SourceType
@@ -99,6 +99,22 @@ class TestYumFinder(BaseYumTest):
         disc_source = finder.find()
         self.assertIsInstance(disc_source, yum.YumDiscoveredSource)
         self.assertEqual([url], disc_source.urls)
+
+    def test_generate_repos_with_plain_list(self):
+        fallback = mock.MagicMock()
+        finder = self.make_finder()
+        repos = [self.factory.make_string() for _ in range(0, 3)]
+        result = finder.generate_repos(repos, fallback)
+        self.assertThat(result, SameMembers(repos))
+        fallback.assert_not_called()
+
+    def test_generate_repos_with_fallback(self):
+        fallback = mock.MagicMock()
+        repos_fallback = [self.factory.make_string() for _ in range(0, 3)]
+        fallback.return_value = repos_fallback
+        finder = self.make_finder()
+        result = finder.generate_repos(None, fallback)
+        self.assertThat(list(result), SameMembers(repos_fallback))
 
     def test_get_source_url(self):
         name = self.factory.make_string()


### PR DESCRIPTION
 - Remove the "hey I need to restart my generator" flag
 - The walk* code can now just request an iterable of repos and it'll
   always get handed the right generator
 - Make derived Centos finder's abstract methods match the base class's
   so there's no awkward arg storage and overriding
 - Remove obsolete tests
 - Fix breakage in tests that were testing an impossible situation where
   they assumed you can have an optimal set of repos AND a custom set
   (the finder's init prevents this!).