### PR TITLE
Catch all failures from repomd loads, add warnings, docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,37 @@ Using the API:
         shutil.filecopyobj(archive, local)
 
 
+Caching
+-------
+
+Soufi uses `dogpile.cache <https://github.com/sqlalchemy/dogpile.cache>`_ to
+provide a convenient mechanism for caching requests when doing repeated
+lookups.  For sources with network-intensive remote discovery (e.g,,
+DNF/Yum-based OSes) this is **strongly recommended**.
+
+For a single-threaded application, an in-memory LRU cache, should be adequate:
+
+.. code:: python
+
+    import pylru
+    import soufi
+
+    LRU_CACHE = pylru.lrucache(size=1024)
+    finder = soufi.finder.factory(
+        'centos', 'cracklib-dicts', '2.9.0-11.el7', soufi.finder.SourceType.os,
+        cache_backend='dogpile.cache.memory',
+        cache_args=dict(cache_dict=LRU_CACHE),
+    )
+    print(finder.find())
+    # Re-using the finder will use cached results
+    print(finder.find('vim-minimal', '7.4.629-8.el7_9'))
+
+More complex applications can use the other backends, e.g., memcached, Redis,
+custom backends, etc.  See the
+`dogpile.cache documentation <https://dogpilecache.sqlalchemy.org/>`_
+for details on backend configuration.
+
+
 Copyright
 ---------
 

--- a/soufi/finder.py
+++ b/soufi/finder.py
@@ -176,6 +176,8 @@ class SourceFinder(metaclass=abc.ABCMeta):
     `find()` should then specify any that were not passed to `__init__`.
     """
 
+    timeout = DEFAULT_TIMEOUT
+
     @property
     @abc.abstractmethod
     def distro(self) -> Union[Distro, str]:

--- a/soufi/finders/ubuntu.py
+++ b/soufi/finders/ubuntu.py
@@ -29,6 +29,8 @@ class UbuntuFinder(finder.SourceFinder):
     #  within threads, at least.  This will cause duplicated work in
     #  concurrent applications, which sadly cannot be avoided.
     #  See: https://bugs.launchpad.net/launchpadlib/+bug/822847
+    # NOTE(nic): workaround an apparent bug in Python 3.7 where the default
+    # maxsize for the functools.lru_cache decorator does not work
     @classmethod
     @functools.lru_cache(maxsize=128)
     def get_archive(cls):

--- a/soufi/finders/ubuntu.py
+++ b/soufi/finders/ubuntu.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
-
+import functools
 import pathlib
 
 from launchpadlib.launchpad import Launchpad
@@ -23,22 +23,26 @@ class UbuntuFinder(finder.SourceFinder):
         urls = tuple(sorted(source.sourceFileUrls()))
         return UbuntuDiscoveredSource(urls, timeout=self.timeout)
 
-    def get_archive(self):
+    # NOTE(nic): launchpadlib is not thread-safe, and its objects cannot be
+    #  pickled, which means we cannot use self._cache here, as it assumes both.
+    #  But this call is expensive, so attempt to minimize remote calls
+    #  within threads, at least.  This will cause duplicated work in
+    #  concurrent applications, which sadly cannot be avoided.
+    #  See: https://bugs.launchpad.net/launchpadlib/+bug/822847
+    @classmethod
+    @functools.lru_cache(maxsize=128)
+    def get_archive(cls):
         """Retrieve, and cache, the LP distro main archive object."""
-
-        def inner():
-            cachedir = pathlib.Path.home().joinpath(".launchpadlib", "cache")
-            lp = Launchpad.login_anonymously(
-                "soufi",
-                "production",
-                cachedir,
-                version="devel",
-                timeout=self.timeout,
-            )
-            distribution = lp.distributions[self.distro]
-            return distribution.main_archive
-
-        return self._cache.get_or_create('get_archive', inner)
+        cachedir = pathlib.Path.home().joinpath(".launchpadlib", "cache")
+        lp = Launchpad.login_anonymously(
+            "soufi",
+            "production",
+            cachedir,
+            version="devel",
+            timeout=cls.timeout,
+        )
+        distribution = lp.distributions[cls.distro]
+        return distribution.main_archive
 
     def get_build(self):
         bins = self.lp_archive.getPublishedBinaries(

--- a/soufi/tests/finders/test_ubuntu_finder.py
+++ b/soufi/tests/finders/test_ubuntu_finder.py
@@ -18,6 +18,10 @@ from soufi.testing import base
 
 
 class TestUbuntuFinder(base.TestCase):
+    def tearDown(self):
+        super().tearDown()
+        ubuntu.UbuntuFinder.get_archive.cache_clear()
+
     def make_finder(self, name=None, version=None, **kwargs):
         if name is None:
             name = self.factory.make_string('name')
@@ -27,15 +31,8 @@ class TestUbuntuFinder(base.TestCase):
 
     def test_init_auths_to_Launchpad_only_once(self):
         login = self.patch(ubuntu.Launchpad, 'login_anonymously')
-        cache = dict()
-        self.make_finder(
-            cache_backend='dogpile.cache.memory',
-            cache_args=dict(cache_dict=cache),
-        )
-        self.make_finder(
-            cache_backend='dogpile.cache.memory',
-            cache_args=dict(cache_dict=cache),
-        )
+        self.make_finder()
+        self.make_finder()
         login.assert_called_once_with(
             "soufi", "production", mock.ANY, version="devel", timeout=30
         )


### PR DESCRIPTION
* There are roughly eleven quintillion failure modes when loading repomd, with zero of them being actionable in any realistic way.  Swallow all failures (not just HTTPErrors) and send back NoneTypes from the subprocess, the callers will similarly roll those over into "no package for you" results.
* Since the YumFinder is designed with the full expectation that a viable, persistent cache is in-place for it to do its work, add an explicit warning if a YumFinder is initialized with the null cache
* Add documentation on how to use caching.
* `launchpadlib` is not thread-safe, and its objects cannot be pickled (https://bugs.launchpad.net/launchpadlib/+bug/822847) which means we cannot use `dogpile.cache` with it, as it assumes both.
* But the call to initialize `launchpadlib` is expensive, so attempt to minimize remote calls within threads, at least.  This will cause duplicated work in concurrent applications, which sadly cannot be avoided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/soufi/22)
<!-- Reviewable:end -->
