### PR TITLE
Bugfix: allow for empty responses from do_task

### DIFF
--- a/soufi/finders/yum.py
+++ b/soufi/finders/yum.py
@@ -235,7 +235,7 @@ def do_task(target, *args):
         process.terminate()
     # re-raise exceptions thrown in child processes; this should keep them
     # from getting cached
-    if isinstance(response[0], Exception):
+    if response and isinstance(response[0], Exception):
         raise response[0]
     return response
 

--- a/soufi/tests/finders/test_yum_finder.py
+++ b/soufi/tests/finders/test_yum_finder.py
@@ -439,6 +439,18 @@ class TestYumFinderHelpers(BaseYumTest):
         self.assertEqual(data, response)
         process.return_value.terminate.assert_called_once_with()
 
+    def test_do_task_empty_response(self):
+        # Mock up a process that yields an "empty-but-successful" response
+        queue = self.patch(yum, 'Queue')
+        queue.return_value.get.return_value = []
+        process = self.patch(yum, 'Process')
+        process.return_value.is_alive.return_value = False
+
+        # Ensure that the process gets shot in the head
+        response = yum.do_task('d', 'e', 'f')
+        self.assertEqual([], response)
+        process.return_value.terminate.assert_not_called()
+
     def test_do_task_reraises_exceptions(self):
         # Actually run a job via do_task and ensure that the resulting
         # exception is intact


### PR DESCRIPTION
Subprocesses that run successfully but generate no output should not cause a stack trace, so make them not do that.

This use case was caused by a small gap in the tests, which is also closed.

Fixes: Issue #21

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/soufi/23)
<!-- Reviewable:end -->
