### PR TITLE
General improvements to PhotonFinder, YumFinder

### DIFF
--- a/soufi/finders/photon.py
+++ b/soufi/finders/photon.py
@@ -47,9 +47,14 @@ class PhotonFinder(yum_finder.YumFinder):
         )
 
     def get_binary_repos(self):
-        return self._get_repos(
-            "//a[text()[not(contains(.,'srpms'))][contains(.,'x86_64')]]/text()"  # noqa: E501
-        )
+        """Retrieve a list of all repo URLs for binary RPM packages.
+
+        Photon OS does not reliably publish repodata for all releases,
+        so double-check all candidate repo dirs before using.
+        """
+        xpath = "//a[text()[not(contains(.,'srpms'))][contains(.,'x86_64')]]/text()"  # noqa: E501
+        suffix = 'repodata/repomd.xml'
+        return [r for r in self._get_repos(xpath) if self.test_url(r + suffix)]
 
     def _walk_source_repos(self, name, version=None):
         # Photon OS does not provide repomd.xml files for their source


### PR DESCRIPTION
A couple of useful improvements:

- Failure to serialize exceptions when doing YumFinder IPC would cause the parent process to hang indefinitely waiting for a response.  Added timeouts to both ends of the queue to remediate.
- The YumFinder IPC can fail to serialize exceptions in some cases.  Add a fallback "generic" exception in those cases.
- Photon OS does not reliably publish repodata for all releases any longer, so double-check all candidate repo dirs before attempting to use them.

Fixes: Issue #25

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/soufi/26)
<!-- Reviewable:end -->
