### PR TITLE
Add a status_code attribute to DownloadError exceptions

### DIFF
--- a/soufi/exceptions.py
+++ b/soufi/exceptions.py
@@ -11,6 +11,18 @@ class SourceNotFound(Exception):
 
 
 class DownloadError(Exception):
-    """Raised when source cannot be downloaded."""
+    """Raised when source cannot be downloaded.
 
-    pass
+    This is most commonly raised due to HTTPError exceptions, so this will
+    also surface the status code from any chained HTTP responses, as a
+    convenience.
+    """
+
+    @property
+    def status_code(self):
+        for arg in self.args:
+            try:
+                return arg.response.status_code
+            except AttributeError:
+                continue
+        return None

--- a/soufi/tests/finders/test_alpine_finder.py
+++ b/soufi/tests/finders/test_alpine_finder.py
@@ -242,9 +242,10 @@ class TestAlpineDiscoveredSource(base.TestCase):
         # Make the tar file and populate it:
         _, tar_file_name = tempfile.mkstemp(dir=tmpdir)
         with tarfile.open(name=tar_file_name, mode='w') as tar:
-            self.assertRaises(
+            exc = self.assertRaises(
                 exceptions.DownloadError, ads.populate_archive, tmpdir, tar
             )
+            self.assertIsNone(exc.status_code)
 
     def test_populate_archive_with_file_scheme(self):
         tmpdir = self.useFixture(fixtures.TempDir()).path

--- a/soufi/tests/test_finder_base.py
+++ b/soufi/tests/test_finder_base.py
@@ -159,13 +159,14 @@ class TestDiscoveredSourceBase(base.TestCase):
         get.return_value = response
 
         tds = self.TestDiscoveredSource(urls=[])
-        self.assertRaises(
+        exc = self.assertRaises(
             exceptions.DownloadError,
             tds.download_file,
             tmpdir,
             target,
             url,
         )
+        self.assertEqual(response.status_code, exc.status_code)
 
         expected_path = pathlib.Path(tmpdir) / target
         get.assert_called_once_with(url, stream=True, timeout=30)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 bandit==1.7.2
 build>=0.7.0
-black==22.1.0
+black>=22.3.0
 coverage==6.3
 fixtures==3.0.0
 flake8==4.0.1


### PR DESCRIPTION
One of the more common causes of `DownloadError` exceptions in the wild is `HTTPError` exceptions.

Surface the status code from the HTTP response as a convenience to callers.

Drive-by: update the version of Black used for tests, for compatibility with modern Click.

Fixes Issue #27

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/soufi/28)
<!-- Reviewable:end -->
