### PR TITLE
Bugfix: Use canonical URLs for CentOS auto-discovery

### DIFF
--- a/soufi/finders/centos.py
+++ b/soufi/finders/centos.py
@@ -11,7 +11,7 @@ from lxml import html  # nosec
 import soufi.finders.yum as yum_finder
 from soufi import finder
 
-VAULT = "https://vault.centos.org/centos"
+VAULT = "https://vault.centos.org/centos/"
 DEFAULT_SEARCH = ('BaseOS', 'os', 'updates', 'extras')
 # Optimal search dirs considered a useful extended set to inspect in
 # addition to the defaults.
@@ -23,7 +23,7 @@ OPTIMAL_SEARCH = ('AppStream', 'PowerTools', 'fasttrack')
 # it is necessary to also check the main mirror when looking for the "current"
 # releases.  Note that the connection is unencrypted, and no HTTPS endpoint
 # is provided.
-MIRROR = "http://mirror.centos.org/centos"
+MIRROR = "http://mirror.centos.org/centos/"
 
 
 class CentosFinder(yum_finder.YumFinder):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 bandit==1.7.2
 build>=0.7.0
-black==22.1.0
+black>=22.3.0
 coverage==6.3
 fixtures==3.0.0
 flake8==4.0.1


### PR DESCRIPTION
Drive-by: update the version of Black used for tests, for compatibility with modern Click.

Fixes Issue #29

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/soufi/30)
<!-- Reviewable:end -->
