### PR TITLE
Provide a more helpful error message on spawn() failures

### DIFF
--- a/soufi/tests/finders/test_yum_finder.py
+++ b/soufi/tests/finders/test_yum_finder.py
@@ -484,9 +484,17 @@ class TestYumFinderHelpers(BaseYumTest):
         # is not intrinsically helpful, so test that we kick back a more
         # useful error message.  See issue #31.
         process = self.patch(yum, 'Process')
-        process.return_value.start.side_effect = RuntimeError
+        process.return_value.start.side_effect = RuntimeError(
+            'Simulating a platform that is not using fork to start children'
+        )
         err = self.assertRaises(SystemExit, yum.do_task, None)
         self.assertIn('FATAL: ', str(err))
+
+    def test_do_task_leaves_other_spawn_errors_alone(self):
+        # As per the above, other RuntimeError exceptions should pass through
+        process = self.patch(yum, 'Process')
+        process.return_value.start.side_effect = RuntimeError
+        self.assertRaises(RuntimeError, yum.do_task, None)
 
 
 # A simple subprocess function that throws a test exception.  Used by

--- a/soufi/tests/finders/test_yum_finder.py
+++ b/soufi/tests/finders/test_yum_finder.py
@@ -478,6 +478,16 @@ class TestYumFinderHelpers(BaseYumTest):
         err = self.assertRaises(RuntimeError, yum.do_task, kaboom, data)
         self.assertEqual(data, str(err))
 
+    def test_do_task_handles_spawn_errors_on_silly_platforms(self):
+        # This simulates calling `process.start()` from the global scope on
+        # platforms that do not support such things.  The default traceback
+        # is not intrinsically helpful, so test that we kick back a more
+        # useful error message.  See issue #31.
+        process = self.patch(yum, 'Process')
+        process.return_value.start.side_effect = RuntimeError
+        err = self.assertRaises(SystemExit, yum.do_task, None)
+        self.assertIn('FATAL: ', str(err))
+
 
 # A simple subprocess function that throws a test exception.  Used by
 # TestYumFinderHelpers.test_do_task_reraises_exceptions

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ setenv =
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 
-whitelist_externals =
+allowlist_externals =
     bash
     echo
     mkdir
@@ -94,10 +94,14 @@ exclude =
     .eggs
 show-source = true
 ignore =
-    D10  # ignore missing docstrings (for now)
-    D202  # No blank lines allowed after function docstring (caused by Black)
-    E203  # Whitespace before ':' (caused by Black)
-    W503  # line breaks after operators (caused by Black)
+    # ignore missing docstrings (for now)
+    D10
+    # No blank lines allowed after function docstring (caused by Black)
+    D202
+    # Whitespace before ':' (caused by Black)
+    E203
+    # line breaks after operators (caused by Black)
+    W503
 
 [testenv:functional]
 commands =


### PR DESCRIPTION
Make a good-faith effort to catch the `RuntimeError` thrown when improperly invoking the YumFinder on non-Linux platforms, and present a useful error message to the user.

Fixes: Issue #31

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/soufi/34)
<!-- Reviewable:end -->
