### PR TITLE
Python: Accomodate `urls` field in PyPI responses

### DIFF
--- a/soufi/finders/python.py
+++ b/soufi/finders/python.py
@@ -46,13 +46,18 @@ class PythonFinder(finder.SourceFinder):
             data = self.get_url(url).json()
         except exceptions.DownloadError:
             raise exceptions.SourceNotFound
-        releases = data['releases']
-        for version, release_data in releases.items():
-            if version != self.version:
-                continue
-            for item in release_data:
-                if item['packagetype'] == 'sdist':
-                    return item['url']
+        if 'releases' in data:
+            releases = data['releases']
+            for version, release_data in releases.items():
+                if version != self.version:
+                    continue
+                for item in release_data:
+                    if item['packagetype'] == 'sdist':
+                        return item['url']
+        elif 'urls' in data:
+            for entry in data['urls']:
+                if entry.get('packagetype') == 'sdist':
+                    return entry['url']
 
         # It should not be possible to get here unless the JSON returned
         # from the index is corrupted.


### PR DESCRIPTION
Spotted while running the functional tests; packages no longer necessarily have a `releases` field containing the URL, there is a new field called `urls` that contains a list of URLs/hashes.

Update the Python finder to make use of it should it find one, and add unit tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/soufi/36)
<!-- Reviewable:end -->
