### PR TITLE
Fix a double-delimiter bug in the CentOS finder

### DIFF
--- a/soufi/finders/centos.py
+++ b/soufi/finders/centos.py
@@ -94,12 +94,12 @@ class CentosFinder(yum_finder.YumFinder):
         """
         for dir in self._get_dirs():
             for subdir in self.repos:
-                url = f"{VAULT}/{dir}/{subdir}/Source/"
+                url = f"{VAULT.rstrip('/')}/{dir}/{subdir}/Source/"
                 if self.test_url(url + "repodata/"):
                     yield url
             if self.optimal_repos:
                 for subdir in OPTIMAL_SEARCH:
-                    url = f"{VAULT}/{dir}/{subdir}/Source/"
+                    url = f"{VAULT.rstrip('/')}/{dir}/{subdir}/Source/"
                     if self.test_url(url + "repodata/"):
                         yield url
 
@@ -112,8 +112,8 @@ class CentosFinder(yum_finder.YumFinder):
         """
 
         def _find_valid_repo_url(dir, subdir):
-            vault_url = f"{VAULT}/{dir}/{subdir}/x86_64/"
-            mirror_url = f"{MIRROR}/{dir}/{subdir}/x86_64/"
+            vault_url = f"{VAULT.rstrip('/')}/{dir}/{subdir}/x86_64/"
+            mirror_url = f"{MIRROR.rstrip('/')}/{dir}/{subdir}/x86_64/"
             for url in vault_url, mirror_url:
                 if self.test_url(url + "os/repodata/"):
                     yield url + "os/"

--- a/soufi/tests/finders/test_centos_finder.py
+++ b/soufi/tests/finders/test_centos_finder.py
@@ -70,7 +70,7 @@ class TestCentosFinder(BaseCentosTest):
         test_url.return_value = True
         result = list(finder.get_source_repos())
         expected = [
-            f"{centos.VAULT}/{dir}/{subdir}/Source/"
+            f"{centos.VAULT}{dir}/{subdir}/Source/"
             for dir in dirs
             for subdir in subdirs
         ]
@@ -86,7 +86,7 @@ class TestCentosFinder(BaseCentosTest):
         test_url.return_value = True
         result = list(finder.get_source_repos())
         expected = [
-            f"{centos.VAULT}/{dir}/{subdir}/Source/"
+            f"{centos.VAULT}{dir}/{subdir}/Source/"
             for dir in dirs
             for subdir in (centos.DEFAULT_SEARCH + centos.OPTIMAL_SEARCH)
         ]
@@ -102,7 +102,7 @@ class TestCentosFinder(BaseCentosTest):
         test_url.return_value = True
         result = list(finder.get_binary_repos())
         expected = [
-            f"{centos.VAULT}/{dir}/{subdir}/x86_64/os/"
+            f"{centos.VAULT}{dir}/{subdir}/x86_64/os/"
             for dir in dirs
             for subdir in subdirs
         ]
@@ -118,7 +118,7 @@ class TestCentosFinder(BaseCentosTest):
         test_url.side_effect = itertools.cycle((False, True))
         result = list(finder.get_binary_repos())
         expected = [
-            f"{centos.VAULT}/{dir}/{subdir}/x86_64/"
+            f"{centos.VAULT}{dir}/{subdir}/x86_64/"
             for dir in dirs
             for subdir in subdirs
         ]
@@ -134,7 +134,7 @@ class TestCentosFinder(BaseCentosTest):
         test_url.side_effect = itertools.cycle((False, False, True))
         result = list(finder.get_binary_repos())
         expected = [
-            f"{centos.MIRROR}/{dir}/{subdir}/x86_64/os/"
+            f"{centos.MIRROR}{dir}/{subdir}/x86_64/os/"
             for dir in dirs
             for subdir in subdirs
         ]
@@ -150,7 +150,7 @@ class TestCentosFinder(BaseCentosTest):
         test_url.side_effect = itertools.cycle((False, False, False, True))
         result = list(finder.get_binary_repos())
         expected = [
-            f"{centos.MIRROR}/{dir}/{subdir}/x86_64/"
+            f"{centos.MIRROR}{dir}/{subdir}/x86_64/"
             for dir in dirs
             for subdir in subdirs
         ]
@@ -166,7 +166,7 @@ class TestCentosFinder(BaseCentosTest):
         test_url.return_value = True
         result = list(finder.get_binary_repos())
         expected = [
-            f"{centos.VAULT}/{dir}/{subdir}/x86_64/os/"
+            f"{centos.VAULT}{dir}/{subdir}/x86_64/os/"
             for dir in dirs
             for subdir in (centos.DEFAULT_SEARCH + centos.OPTIMAL_SEARCH)
         ]
@@ -182,7 +182,7 @@ class TestCentosFinder(BaseCentosTest):
         test_url.side_effect = itertools.cycle((False, True))
         result = list(finder.get_binary_repos())
         expected = [
-            f"{centos.VAULT}/{dir}/{subdir}/x86_64/"
+            f"{centos.VAULT}{dir}/{subdir}/x86_64/"
             for dir in dirs
             for subdir in (centos.DEFAULT_SEARCH + centos.OPTIMAL_SEARCH)
         ]
@@ -198,7 +198,7 @@ class TestCentosFinder(BaseCentosTest):
         test_url.side_effect = itertools.cycle((False, False, True))
         result = list(finder.get_binary_repos())
         expected = [
-            f"{centos.MIRROR}/{dir}/{subdir}/x86_64/os/"
+            f"{centos.MIRROR}{dir}/{subdir}/x86_64/os/"
             for dir in dirs
             for subdir in (centos.DEFAULT_SEARCH + centos.OPTIMAL_SEARCH)
         ]
@@ -214,7 +214,7 @@ class TestCentosFinder(BaseCentosTest):
         test_url.side_effect = itertools.cycle((False, False, False, True))
         result = list(finder.get_binary_repos())
         expected = [
-            f"{centos.MIRROR}/{dir}/{subdir}/x86_64/"
+            f"{centos.MIRROR}{dir}/{subdir}/x86_64/"
             for dir in dirs
             for subdir in (centos.DEFAULT_SEARCH + centos.OPTIMAL_SEARCH)
         ]


### PR DESCRIPTION
Noticed when running the functional tests.  Also clean up a bunch of unit tests that were enforcing bad behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/soufi/37)
<!-- Reviewable:end -->
