### PR TITLE
Add a finder for Alma Linux

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -83,5 +83,5 @@ There is much that can be improved in most parts of this code::
 
 
 .. footer::
-  Soufi is copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+  Soufi is copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
   All rights reserved.

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -11,9 +11,8 @@ The test suite can be run via the `hatch` utility:
 
     hatch run ci
 
-will run the Python 3 tests, the PEP8 tests, Bandit (security
-checker), and code formatting checks. Test coverage is also displayed
-and without 100% test coverage the tests will fail.
+will run the Python 3 tests, the PEP8 tests, and code formatting checks. Test
+coverage is also displayed and without 100% test coverage the tests will fail.
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,7 @@ Currently supported finders are:
  - CentOS packages
  - Alpine packages
  - Photon OS packages
+ - Alma packages
  - NPM packages
  - Python sdists
  - Golang modules

--- a/README.rst
+++ b/README.rst
@@ -114,5 +114,5 @@ for details on backend configuration.
 Copyright
 ---------
 
-Soufi is copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+Soufi is copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 All rights reserved.

--- a/soufi/finder.py
+++ b/soufi/finder.py
@@ -40,6 +40,7 @@ class Distro(enum.Enum):
     centos = "centos"
     alpine = "alpine"
     photon = "photon"
+    alma = "alma"
 
 
 class DiscoveredSource(metaclass=abc.ABCMeta):

--- a/soufi/finder.py
+++ b/soufi/finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 import abc

--- a/soufi/finders/alma.py
+++ b/soufi/finders/alma.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2023 Cisco Systems, Inc. and its affiliates
+# All rights reserved.
+
+import re
+
+from lxml import html
+
+import soufi.finders.yum as yum_finder
+from soufi import finder
+
+VAULT = "https://repo.almalinux.org/vault"
+# Alma does their very best to be a faithful CentOS clone.  Up to and
+# including this little gem.  See the CentosFinder for an explanation.
+CURRENT = "https://repo.almalinux.org/almalinux"
+# Rather than aimlessly poke around their CDN, use this hopefully-sensible
+# list of search dirs when looking for repodata
+DEFAULT_SEARCH = ('BaseOS', 'AppStream', 'extras', 'cloud', 'devel')
+
+
+class AlmaFinder(yum_finder.YumFinder):
+    """Find Alma Linux source files.
+
+    By default, Iterates over the index at https://repo.almalinux.org/vault/
+    """
+
+    distro = finder.Distro.alma.value
+
+    def _get_dirs(self):
+        """Get all the possible Vault dirs that could match."""
+        content = self.get_url(VAULT).content
+        tree = html.fromstring(content)
+        # Ignore beta releases; we may want to make this a switchable behavior
+        retval = tree.xpath("//a/text()[not(contains(.,'-beta'))]")
+        # Alma Vault is fond of symlinking the current point release to a
+        # directory with just the major version number, e.g., `6.10/`->`6/`.
+        # This means that such directories are inherently unstable and their
+        # contents are subject to change without notice, so we'll ignore
+        # them in favour of the "full" names.
+        dirs = [dir.rstrip('/') for dir in retval if re.match(r'\d+\.\d', dir)]
+
+        # Walk the tree backwards, so that newer releases get searched first
+        return reversed(dirs)
+
+    def get_source_repos(self):
+        """Determine which source search paths are valid.
+
+        Spams the vault with HEAD requests and keeps the ones that hit.
+
+        This is implemented as a generator so that the methods in the
+        YumFinder base class can "load as it goes", rather than having to
+        do a ton of discovery up-front that might end up being wasted.
+        Absolutely everything is cached, so the relative overhead of having
+        to run the generator over when re-walking the list of repos is minimal.
+        """
+        for dir in self._get_dirs():
+            for subdir in DEFAULT_SEARCH:
+                url = f"{VAULT.rstrip('/')}/{dir}/{subdir}/Source/"
+                if self.test_url(url + "repodata/"):
+                    yield url
+
+    def get_binary_repos(self):
+        """Determine which binary search paths are valid.
+
+        Spams the vault with HEAD requests and keeps the ones that hit.
+
+        This is also implemented as a generator.  See get_source_repos().
+        """
+
+        def _find_valid_repo_url(dir, subdir):
+            vault_url = f"{VAULT.rstrip('/')}/{dir}/{subdir}/x86_64/"
+            current_url = f"{CURRENT.rstrip('/')}/{dir}/{subdir}/x86_64/"
+            for url in vault_url, current_url:
+                if self.test_url(url + "os/repodata/"):
+                    yield url + "os/"
+                    break
+
+        for dir in self._get_dirs():
+            for subdir in DEFAULT_SEARCH:
+                yield from _find_valid_repo_url(dir, subdir)

--- a/soufi/finders/centos.py
+++ b/soufi/finders/centos.py
@@ -4,8 +4,6 @@
 import re
 from typing import Iterable
 
-# Bandit reports this as vulnerable but it's OK in lxml now,
-# defusedxml's lxml support is deprecated as a result.
 from lxml import html
 
 import soufi.finders.yum as yum_finder

--- a/soufi/finders/centos.py
+++ b/soufi/finders/centos.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2022-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 import re

--- a/soufi/finders/photon.py
+++ b/soufi/finders/photon.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 from lxml import html

--- a/soufi/finders/photon.py
+++ b/soufi/finders/photon.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
-# Bandit reports this as vulnerable but it's OK in lxml now,
-# defusedxml's lxml support is deprecated as a result.
 from lxml import html
 
 import soufi.exceptions

--- a/soufi/functional/test_functional.py
+++ b/soufi/functional/test_functional.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 import logging

--- a/soufi/functional/test_functional.py
+++ b/soufi/functional/test_functional.py
@@ -265,3 +265,18 @@ class FunctionalPythonTests(FunctionalFinderTests):
         url = 'https://files.pythonhosted.org/packages/0f/80/d8883f12689a55e333d221bb9a56c727e976f5a8e9dc862efeac9f40d296/SQLAlchemy-1.4.31.tar.gz'  # noqa: E501
         result = python.find()
         self.assertEqual([url], result.urls)
+
+
+class FunctionalAlmaTests(FunctionalFinderTests):
+    def test_find_binary_from_source(self):
+        alma = finder.factory(
+            'alma',
+            name='glibc-common',
+            version='2.34-60.el9_2.7',
+            s_type=SourceType.os,
+            cache_backend='dogpile.cache.memory_pickle',
+            cache_args=dict(cache_dict=FUNCTEST_CACHE),
+        )
+        url = 'https://repo.almalinux.org/vault/9.2/BaseOS/Source/Packages/glibc-2.34-60.el9_2.7.src.rpm'  # noqa: E501
+        result = alma.find()
+        self.assertEqual([url], result.urls)

--- a/soufi/testing/base.py
+++ b/soufi/testing/base.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 import itertools

--- a/soufi/testing/base.py
+++ b/soufi/testing/base.py
@@ -6,6 +6,7 @@ from importlib import import_module
 from unittest import mock
 from unittest.mock import MagicMock
 
+import requests
 import testtools
 
 from soufi.testing import factory
@@ -92,3 +93,29 @@ class TestCase(testtools.TestCase):
         effects = list(mock_obj.side_effect)
         effects.append(extra_value)
         mock_obj.side_effect = effects
+
+    def patch_get_with_response(self, response_code, data=None, json=None):
+        """Patch `requests.get` with the provided values.
+
+        :param response_code: A requests.codes value, to mimic an HTTP status
+        :param data: A string-like object to mimic Response.content
+        :param json: A dict or list, to mimic what Response.json() would return
+        :return: The created MagicMock, to add side-effects, etc.
+        """
+        fake_response = mock.MagicMock()
+        fake_response.return_value.status_code = response_code
+        fake_response.return_value.content = data
+        fake_response.return_value.json.return_value = json
+        return self.patch(requests, 'get', fake_response)
+
+    def patch_head_with_response(self, response_code):
+        """Patch `requests.head` with the provided values.
+
+        HEAD requests have an empty message body, so no data is accepted.
+
+        :param response_code: A requests.codes value, to mimic an HTTP status
+        :return: The created MagicMock, to add side-effects, etc.
+        """
+        fake_response = mock.MagicMock()
+        fake_response.return_value.status_code = response_code
+        return self.patch(requests, 'head', fake_response)

--- a/soufi/tests/finders/test_alma_finder.py
+++ b/soufi/tests/finders/test_alma_finder.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2023 Cisco Systems, Inc. and its affiliates
+# All rights reserved.
+
+from unittest import mock
+
+import requests
+
+from soufi.finder import SourceType
+from soufi.finders import alma, yum
+from soufi.testing import base
+
+
+class BaseAlmaTest(base.TestCase):
+    def make_finder(self, name=None, version=None, **kwargs):
+        if name is None:
+            name = self.factory.make_string('name')
+        if version is None:
+            version = self.factory.make_string('version')
+        if 'source_repos' not in kwargs:
+            kwargs['source_repos'] = ['']
+        if 'binary_repos' not in kwargs:
+            kwargs['binary_repos'] = ['']
+        return alma.AlmaFinder(name, version, SourceType.os, **kwargs)
+
+    def make_response(self, data, code):
+        fake_response = mock.MagicMock()
+        fake_response.content = data
+        fake_response.status_code = code
+        return fake_response
+
+    def make_href(self, text):
+        return f'<a href="{text}">{text}</a>'
+
+    def make_top_page_content(self, versions):
+        links = [self.make_href(v) for v in versions]
+        return "\n".join(links)
+
+
+class TestAlmaFinder(BaseAlmaTest):
+    def test_find(self):
+        finder = self.make_finder()
+        url = self.factory.make_url()
+        self.patch(finder, 'get_source_url').return_value = url
+        disc_source = finder.find()
+        self.assertIsInstance(disc_source, yum.YumDiscoveredSource)
+        self.assertEqual([url], disc_source.urls)
+
+    def test__get_dirs(self):
+        finder = self.make_finder()
+        top_repos = ('1.0.123', '2.1.3456', 'bogus', '3.7.89-beta', '3')
+        top_data = self.make_top_page_content(top_repos)
+        get = self.patch(requests, 'get')
+        get.return_value = self.make_response(top_data, requests.codes.ok)
+        result = list(finder._get_dirs())
+        # Ensure that only the items we're interested in come back
+        self.assertEqual(['2.1.3456', '1.0.123'], result)
+        get.assert_called_once_with(alma.VAULT, timeout=30)
+
+    def test__get_source_repos(self):
+        finder = self.make_finder()
+        dirs = [self.factory.make_string() for _ in range(3)]
+        get_dirs = self.patch(finder, '_get_dirs')
+        get_dirs.return_value = dirs
+        test_url = self.patch(finder, 'test_url')
+        test_url.return_value = True
+        result = list(finder.get_source_repos())
+        expected = [
+            f"{alma.VAULT}/{dir}/{subdir}/Source/"
+            for dir in dirs
+            for subdir in alma.DEFAULT_SEARCH
+        ]
+        self.assertEqual(expected, result)
+
+    def test__get_binary_repos(self):
+        finder = self.make_finder()
+        dirs = [self.factory.make_string() for _ in range(3)]
+        get_dirs = self.patch(finder, '_get_dirs')
+        get_dirs.return_value = dirs
+        test_url = self.patch(finder, 'test_url')
+        test_url.return_value = True
+        result = list(finder.get_binary_repos())
+        expected = [
+            f"{alma.VAULT}/{dir}/{subdir}/x86_64/os/"
+            for dir in dirs
+            for subdir in alma.DEFAULT_SEARCH
+        ]
+        self.assertEqual(expected, result)

--- a/soufi/tests/finders/test_alma_finder.py
+++ b/soufi/tests/finders/test_alma_finder.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
-from unittest import mock
-
 import requests
 
 from soufi.finder import SourceType
@@ -21,12 +19,6 @@ class BaseAlmaTest(base.TestCase):
         if 'binary_repos' not in kwargs:
             kwargs['binary_repos'] = ['']
         return alma.AlmaFinder(name, version, SourceType.os, **kwargs)
-
-    def make_response(self, data, code):
-        fake_response = mock.MagicMock()
-        fake_response.content = data
-        fake_response.status_code = code
-        return fake_response
 
     def make_href(self, text):
         return f'<a href="{text}">{text}</a>'
@@ -49,8 +41,7 @@ class TestAlmaFinder(BaseAlmaTest):
         finder = self.make_finder()
         top_repos = ('1.0.123', '2.1.3456', 'bogus', '3.7.89-beta', '3')
         top_data = self.make_top_page_content(top_repos)
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(top_data, requests.codes.ok)
+        get = self.patch_get_with_response(requests.codes.ok, top_data)
         result = list(finder._get_dirs())
         # Ensure that only the items we're interested in come back
         self.assertEqual(['2.1.3456', '1.0.123'], result)

--- a/soufi/tests/finders/test_centos_finder.py
+++ b/soufi/tests/finders/test_centos_finder.py
@@ -2,7 +2,6 @@
 # All rights reserved.
 
 import itertools
-from unittest import mock
 
 import requests
 
@@ -22,12 +21,6 @@ class BaseCentosTest(base.TestCase):
         if 'binary_repos' not in kwargs:
             kwargs['binary_repos'] = ['']
         return centos.CentosFinder(name, version, SourceType.os, **kwargs)
-
-    def make_response(self, data, code):
-        fake_response = mock.MagicMock()
-        fake_response.content = data
-        fake_response.status_code = code
-        return fake_response
 
     def make_href(self, text):
         return f'<a href="{text}">{text}</a>'
@@ -53,8 +46,7 @@ class TestCentosFinder(BaseCentosTest):
         finder = self.make_finder()
         top_repos = ('1.0.123', '2.1.3456', 'bogus', '3.7.89', '3')
         top_data = self.make_top_page_content(top_repos)
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(top_data, requests.codes.ok)
+        get = self.patch_get_with_response(requests.codes.ok, top_data)
         result = list(finder._get_dirs())
         # Ensure that only the items we're interested in come back
         self.assertEqual(['3.7.89', '2.1.3456', '1.0.123'], result)

--- a/soufi/tests/finders/test_centos_finder.py
+++ b/soufi/tests/finders/test_centos_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 import itertools

--- a/soufi/tests/finders/test_debian_finder.py
+++ b/soufi/tests/finders/test_debian_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 import pathlib

--- a/soufi/tests/finders/test_gem_finder.py
+++ b/soufi/tests/finders/test_gem_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 import requests

--- a/soufi/tests/finders/test_gem_finder.py
+++ b/soufi/tests/finders/test_gem_finder.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
-from unittest import mock
-
 import requests
 import testtools
 
@@ -20,24 +18,17 @@ class TestGemFinder(base.TestCase):
             version = self.factory.make_string('version')
         return gem.GemFinder(name, version, SourceType.gem)
 
-    def make_response(self, code):
-        fake_response = mock.MagicMock()
-        fake_response.status_code = code
-        return fake_response
-
     def test_get_source_url(self):
         finder = self.make_finder()
         url = f'{gem.GEM_DOWNLOADS}{finder.name}-{finder.version}.gem'
 
-        head = self.patch(requests, 'head')
-        head.return_value = self.make_response(requests.codes.ok)
+        head = self.patch_head_with_response(requests.codes.ok)
         found_url = finder.get_source_url()
         self.assertEqual(found_url, url)
         head.assert_called_once_with(url, timeout=30)
 
     def test_get_source_info_raises_when_response_fails(self):
-        head = self.patch(requests, 'head')
-        head.return_value = self.make_response(requests.codes.not_found)
+        self.patch_head_with_response(requests.codes.not_found)
         finder = self.make_finder()
         with testtools.ExpectedException(exceptions.SourceNotFound):
             finder.get_source_url()

--- a/soufi/tests/finders/test_golang_finder.py
+++ b/soufi/tests/finders/test_golang_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 import requests

--- a/soufi/tests/finders/test_java_finder.py
+++ b/soufi/tests/finders/test_java_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 import requests

--- a/soufi/tests/finders/test_npm_finder.py
+++ b/soufi/tests/finders/test_npm_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 import requests

--- a/soufi/tests/finders/test_npm_finder.py
+++ b/soufi/tests/finders/test_npm_finder.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
-from unittest import mock
-
 import requests
 import testtools
 
@@ -20,19 +18,12 @@ class TestNPMFinder(base.TestCase):
             version = self.factory.make_string('version')
         return npm.NPMFinder(name, version, SourceType.npm)
 
-    def make_response(self, data, code):
-        fake_response = mock.MagicMock()
-        fake_response.json.return_value = data
-        fake_response.status_code = code
-        return fake_response
-
     def test_get_source_url(self):
         finder = self.make_finder()
         url = self.factory.make_url()
         data = dict(dist=dict(tarball=url))
 
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(data, requests.codes.ok)
+        get = self.patch_get_with_response(requests.codes.ok, json=data)
         found_url = finder.get_source_url()
         self.assertEqual(found_url, url)
         get.assert_called_once_with(
@@ -41,8 +32,7 @@ class TestNPMFinder(base.TestCase):
         )
 
     def test_get_source_info_raises_when_response_fails(self):
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response([], requests.codes.not_found)
+        self.patch_get_with_response(requests.codes.not_found)
         finder = self.make_finder()
         with testtools.ExpectedException(exceptions.SourceNotFound):
             finder.get_source_url()

--- a/soufi/tests/finders/test_photon_finder.py
+++ b/soufi/tests/finders/test_photon_finder.py
@@ -89,8 +89,7 @@ class TestPhotonFinder(BasePhotonTest):
 
     def test__get_source_repos_top_level_failure_throws_exception(self):
         finder = self.make_finder()
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(b'', requests.codes.not_found)
+        self.patch_get_with_response(requests.codes.not_found)
         self.assertRaises(exceptions.DownloadError, finder.get_source_repos)
 
     def test__get_source_repos_subdir_failure_omits_subdirs(self):
@@ -157,8 +156,7 @@ class TestPhotonFinder(BasePhotonTest):
 
     def test__get_binary_repos_top_level_failure_throws_exception(self):
         finder = self.make_finder()
-        get = self.patch(requests, 'get')
-        get.return_value = self.make_response(b'', requests.codes.not_found)
+        self.patch_get_with_response(requests.codes.not_found)
         self.assertRaises(exceptions.DownloadError, finder.get_binary_repos)
 
     def test__get_binary_repos_subdir_failure_omits_subdirs(self):

--- a/soufi/tests/finders/test_photon_finder.py
+++ b/soufi/tests/finders/test_photon_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 from unittest import mock

--- a/soufi/tests/finders/test_python_finder.py
+++ b/soufi/tests/finders/test_python_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 from unittest import mock

--- a/soufi/tests/finders/test_rhel_finder.py
+++ b/soufi/tests/finders/test_rhel_finder.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
+
 from testtools.matchers import SameMembers
 
 from soufi.finder import SourceType

--- a/soufi/tests/finders/test_rhel_finder.py
+++ b/soufi/tests/finders/test_rhel_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 from testtools.matchers import SameMembers

--- a/soufi/tests/finders/test_yum_finder.py
+++ b/soufi/tests/finders/test_yum_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 import io

--- a/soufi/tests/finders/test_yum_finder.py
+++ b/soufi/tests/finders/test_yum_finder.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
+
 import io
 import string
 from itertools import repeat
@@ -59,12 +60,6 @@ class BaseYumTest(base.TestCase):
         if 'binary_repos' not in kwargs:
             kwargs['binary_repos'] = []
         return YumFinderImpl(name, version, SourceType.os, **kwargs)
-
-    def make_response(self, data, code):
-        fake_response = mock.MagicMock()
-        fake_response.content = data
-        fake_response.status_code = code
-        return fake_response
 
     def make_package(self, n=None, e=None, v=None, r=None, a=None, epoch=None):
         # `epoch` is `name` or `ver`, to denote where to inject it
@@ -326,15 +321,13 @@ class TestYumFinderClassHelpers(BaseYumTest):
 
     def test__test_url_true(self):
         url = self.factory.make_url()
-        fake_req = self.patch(requests, 'head')
-        fake_req.return_value = self.make_response('', requests.codes.ok)
+        self.patch_head_with_response(requests.codes.ok)
         finder = self.make_finder()
         self.assertTrue(finder.test_url(url))
 
     def test__test_url_false(self):
         url = self.factory.make_url()
-        fake_req = self.patch(requests, 'head')
-        fake_req.return_value = self.make_response('', requests.codes.teapot)
+        self.patch_head_with_response(requests.codes.teapot)
         finder = self.make_finder()
         self.assertFalse(finder.test_url(url))
 

--- a/soufi/tests/test_factory.py
+++ b/soufi/tests/test_factory.py
@@ -26,6 +26,7 @@ class TestFinderFactory(base.TestCase):
 
     def test_supported_types(self):
         expected = [
+            'alma',
             'alpine',
             'centos',
             'debian',

--- a/soufi/tests/test_factory.py
+++ b/soufi/tests/test_factory.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2021-2023 Cisco Systems, Inc. and its affiliates
 # All rights reserved.
 
 from unittest.mock import MagicMock


### PR DESCRIPTION
A sensibly-distributed little RPM-based distro:

https://repo.almalinux.org/

This finder tries to take the best bits from the UBI, CentOS, and Photon OS finders to make something small, no-nonsense, and performant.

Drive-by: banish all now-unused `nosec` markers, and references to silly things Bandit used to do.

Fixes: Issue #40

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/soufi/48)
<!-- Reviewable:end -->
