### PR TITLE
Bugfix: s/Alma/AlmaLinux/g

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Currently supported finders are:
  - CentOS packages
  - Alpine packages
  - Photon OS packages
- - Alma packages
+ - AlmaLinux OS packages
  - NPM packages
  - Python sdists
  - Golang modules

--- a/soufi/finder.py
+++ b/soufi/finder.py
@@ -40,7 +40,7 @@ class Distro(enum.Enum):
     centos = "centos"
     alpine = "alpine"
     photon = "photon"
-    alma = "alma"
+    almalinux = "almalinux"
 
 
 class DiscoveredSource(metaclass=abc.ABCMeta):

--- a/soufi/finders/almalinux.py
+++ b/soufi/finders/almalinux.py
@@ -9,7 +9,7 @@ import soufi.finders.yum as yum_finder
 from soufi import finder
 
 VAULT = "https://repo.almalinux.org/vault"
-# Alma does their very best to be a faithful CentOS clone.  Up to and
+# AlmaLinux does their very best to be a faithful CentOS clone.  Up to and
 # including this little gem.  See the CentosFinder for an explanation.
 CURRENT = "https://repo.almalinux.org/almalinux"
 # Rather than aimlessly poke around their CDN, use this hopefully-sensible
@@ -17,13 +17,13 @@ CURRENT = "https://repo.almalinux.org/almalinux"
 DEFAULT_SEARCH = ('BaseOS', 'AppStream', 'extras', 'cloud', 'devel')
 
 
-class AlmaFinder(yum_finder.YumFinder):
-    """Find Alma Linux source files.
+class AlmaLinuxFinder(yum_finder.YumFinder):
+    """Find AlmaLinux source files.
 
     By default, Iterates over the index at https://repo.almalinux.org/vault/
     """
 
-    distro = finder.Distro.alma.value
+    distro = finder.Distro.almalinux.value
 
     def _get_dirs(self):
         """Get all the possible Vault dirs that could match."""
@@ -31,7 +31,7 @@ class AlmaFinder(yum_finder.YumFinder):
         tree = html.fromstring(content)
         # Ignore beta releases; we may want to make this a switchable behavior
         retval = tree.xpath("//a/text()[not(contains(.,'-beta'))]")
-        # Alma Vault is fond of symlinking the current point release to a
+        # AlmaLinux Vault is fond of symlinking the current point release to a
         # directory with just the major version number, e.g., `6.10/`->`6/`.
         # This means that such directories are inherently unstable and their
         # contents are subject to change without notice, so we'll ignore

--- a/soufi/functional/test_functional.py
+++ b/soufi/functional/test_functional.py
@@ -269,8 +269,8 @@ class FunctionalPythonTests(FunctionalFinderTests):
 
 class FunctionalAlmaTests(FunctionalFinderTests):
     def test_find_binary_from_source(self):
-        alma = finder.factory(
-            'alma',
+        almalinux = finder.factory(
+            'almalinux',
             name='glibc-common',
             version='2.34-60.el9_2.7',
             s_type=SourceType.os,
@@ -278,5 +278,5 @@ class FunctionalAlmaTests(FunctionalFinderTests):
             cache_args=dict(cache_dict=FUNCTEST_CACHE),
         )
         url = 'https://repo.almalinux.org/vault/9.2/BaseOS/Source/Packages/glibc-2.34-60.el9_2.7.src.rpm'  # noqa: E501
-        result = alma.find()
+        result = almalinux.find()
         self.assertEqual([url], result.urls)

--- a/soufi/tests/finders/test_alma_finder.py
+++ b/soufi/tests/finders/test_alma_finder.py
@@ -4,7 +4,7 @@
 import requests
 
 from soufi.finder import SourceType
-from soufi.finders import alma, yum
+from soufi.finders import almalinux, yum
 from soufi.testing import base
 
 
@@ -18,7 +18,9 @@ class BaseAlmaTest(base.TestCase):
             kwargs['source_repos'] = ['']
         if 'binary_repos' not in kwargs:
             kwargs['binary_repos'] = ['']
-        return alma.AlmaFinder(name, version, SourceType.os, **kwargs)
+        return almalinux.AlmaLinuxFinder(
+            name, version, SourceType.os, **kwargs
+        )
 
     def make_href(self, text):
         return f'<a href="{text}">{text}</a>'
@@ -45,7 +47,7 @@ class TestAlmaFinder(BaseAlmaTest):
         result = list(finder._get_dirs())
         # Ensure that only the items we're interested in come back
         self.assertEqual(['2.1.3456', '1.0.123'], result)
-        get.assert_called_once_with(alma.VAULT, timeout=30)
+        get.assert_called_once_with(almalinux.VAULT, timeout=30)
 
     def test__get_source_repos(self):
         finder = self.make_finder()
@@ -56,9 +58,9 @@ class TestAlmaFinder(BaseAlmaTest):
         test_url.return_value = True
         result = list(finder.get_source_repos())
         expected = [
-            f"{alma.VAULT}/{dir}/{subdir}/Source/"
+            f"{almalinux.VAULT}/{dir}/{subdir}/Source/"
             for dir in dirs
-            for subdir in alma.DEFAULT_SEARCH
+            for subdir in almalinux.DEFAULT_SEARCH
         ]
         self.assertEqual(expected, result)
 
@@ -71,8 +73,8 @@ class TestAlmaFinder(BaseAlmaTest):
         test_url.return_value = True
         result = list(finder.get_binary_repos())
         expected = [
-            f"{alma.VAULT}/{dir}/{subdir}/x86_64/os/"
+            f"{almalinux.VAULT}/{dir}/{subdir}/x86_64/os/"
             for dir in dirs
-            for subdir in alma.DEFAULT_SEARCH
+            for subdir in almalinux.DEFAULT_SEARCH
         ]
         self.assertEqual(expected, result)

--- a/soufi/tests/test_factory.py
+++ b/soufi/tests/test_factory.py
@@ -26,7 +26,7 @@ class TestFinderFactory(base.TestCase):
 
     def test_supported_types(self):
         expected = [
-            'alma',
+            'almalinux',
             'alpine',
             'centos',
             'debian',


### PR DESCRIPTION
According to their trademark usage policy at
https://almalinux.org/p/the-almalinux-os-trademark-usage-policy/ the proper name of the distro is "AlmaLinux OS", so let's respect that.

Relates: Issue #40

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/soufi/52)
<!-- Reviewable:end -->
