### PR TITLE
Bugfix: Keep `import soufi` as a useable/useful entrypoint

### DIFF
--- a/soufi/__init__.py
+++ b/soufi/__init__.py
@@ -1,0 +1,1 @@
+from soufi import exceptions, finder  # noqa: F401


### PR DESCRIPTION
commit b12334e94656cec91151ea297e39b298401f9ac4 introduced a small regression with importing the library; ensure that `soufi.exceptions`, `soufi.finders`, etc., will still work when importing the top-level library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/soufi/53)
<!-- Reviewable:end -->
