### PR TITLE
Move the `warnings.formatwarning` call into the CLI

### DIFF
--- a/soufi/cli.py
+++ b/soufi/cli.py
@@ -6,6 +6,7 @@ import functools
 import os
 import shutil
 import sys
+import warnings
 
 from soufi import exceptions, finder
 
@@ -15,6 +16,7 @@ try:
 except ImportError:
     sys.exit("CLI support not installed; please install soufi[cli]")
 
+warnings.formatwarning = lambda msg, *x, **y: f'WARNING: {msg}\n'
 
 # Configure a small-ish in-memory LRU cache to speed up operations
 LRU_CACHE = pylru.lrucache(size=512)

--- a/soufi/finders/alpine.py
+++ b/soufi/finders/alpine.py
@@ -15,8 +15,6 @@ from typing import Iterable, Union
 
 from soufi import exceptions, finder
 
-warnings.formatwarning = lambda msg, *x, **y: f'WARNING: {msg}\n'
-
 # Shell snippet that will source an APKBUILD and spit out the vars that we
 # need. CARCH is set to work around a bug in 3.12.0 scripts. CTARGET_ARCH
 # is needed for more complex scripts like `community/go`.

--- a/soufi/finders/yum.py
+++ b/soufi/finders/yum.py
@@ -18,8 +18,6 @@ from dogpile.cache.backends.null import NullBackend
 
 from soufi import exceptions, finder
 
-warnings.formatwarning = lambda msg, *x, **y: f"WARNING: {msg}\n"
-
 
 class YumFinder(finder.SourceFinder, metaclass=abc.ABCMeta):
     """An abstract base class for making Yum-based finders.


### PR DESCRIPTION
This setting is global, so it is bad form for libraries to alter it; the top-level application should be responsible for such things.

Fixes: Issue #56

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/soufi/57)
<!-- Reviewable:end -->
