### PR TITLE
Fix Maven searches

### DIFF
--- a/soufi/finders/java.py
+++ b/soufi/finders/java.py
@@ -12,17 +12,31 @@ class JavaFinder(finder.SourceFinder):
     """Find Java source JARs.
 
     Uses the SOLR search at https://search.maven.org/
+
+    :param group_id: Optional Maven groupId to narrow the search. Without
+        this, the search may return versions from different artifacts that
+        share the same artifactId.
     """
 
     distro = finder.SourceType.java.value
+
+    def __init__(self, *args, group_id=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.group_id = group_id
 
     def _find(self):
         source_url = self.get_source_url()
         return JavaDiscoveredSource([source_url], timeout=self.timeout)
 
     def _get_release_history(self):
+        # Build query - if group_id is provided, filter by it to avoid
+        # matching different artifacts with the same name.
+        if self.group_id:
+            query = f'g:{self.group_id} AND a:{self.name} l:sources'
+        else:
+            query = f'a:{self.name} l:sources'
         params = dict(
-            q=f'a:{self.name} l:sources',
+            q=query,
             rows=200,
             core='gav',
             wt='json',

--- a/soufi/tests/finders/test_java_finder.py
+++ b/soufi/tests/finders/test_java_finder.py
@@ -139,6 +139,24 @@ class TestJavaFinder(base.TestCase):
             finder.get_release_history,
         )
 
+    def test_get_release_history_uses_group_id(self):
+        name = self.factory.make_string()
+        group_id = self.factory.make_string()
+        finder = java.JavaFinder(
+            name,
+            self.factory.make_string(),
+            SourceType.java,
+            group_id=group_id,
+        )
+        data = {'response': {'docs': [{'v': '1.0.0', 'timestamp': 1000}]}}
+        get = self.patch_get_with_response(requests.codes.ok, json=data)
+
+        finder.get_release_history()
+        call_args = get.call_args
+        query = call_args.kwargs['params']['q']
+        self.assertIn(f'g:{group_id}', query)
+        self.assertIn(f'a:{name}', query)
+
 
 class TestNPMDiscoveredSource(base.TestCase):
     def make_discovered_source(self, url=None):


### PR DESCRIPTION
Add an optional Maven groupId to narrow the search. Without this, the search may return versions from different artifacts that share the same artifactId.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/soufi/71)
<!-- Reviewable:end -->
